### PR TITLE
feat: add meal plan viewer page with history

### DIFF
--- a/docs/plans/2026-04-05-002-feat-meal-plan-viewer-page-plan.md
+++ b/docs/plans/2026-04-05-002-feat-meal-plan-viewer-page-plan.md
@@ -1,0 +1,169 @@
+---
+title: "feat: Add meal plan viewer page with history"
+type: feat
+status: completed
+date: 2026-04-05
+---
+
+# feat: Add meal plan viewer page with history
+
+## Overview
+
+Add a `/plans` page that shows the current meal plan and a history of past plans. The storage layer (`MealPlanRepository.list()`) already exists — this needs an API endpoint to expose it and a page to display it.
+
+## Problem Frame
+
+Users can generate meal plans via the `/generate` page, but there's no way to view previous plans or revisit the current week's plan without regenerating. The generate page shows the plan only in the same session — refreshing loses it. A dedicated viewer page lets users check the current plan at any time and browse past weeks.
+
+Related: dancj/meal-assistant#9
+
+## Requirements Trace
+
+- R1. `/plans` page shows the current week's meal plan (dinners + grocery list)
+- R2. Page shows a list of past meal plans with their `weekOf` dates
+- R3. Clicking a past plan expands or navigates to show its full details
+- R4. Navigation header includes a link to `/plans`
+- R5. Loading and empty states are handled gracefully
+
+## Scope Boundaries
+
+- No pagination — `MealPlanRepository.list(10)` is sufficient for household-scale history
+- No plan editing or deletion — read-only viewer
+- No changes to the generate page — it keeps its inline plan display
+- No new storage methods — `list()` and `getCurrent()` already exist
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- **Storage interface:** `MealPlanRepository.list(limit?: number)` in `src/lib/storage/types.ts` — returns `StoredMealPlan[]` ordered by `created_at DESC`, default limit 10
+- **Current plan API:** `src/app/api/plan/current/route.ts` — pattern to follow for the new list endpoint
+- **Plan display template:** `src/app/generate/page.tsx` lines 176-235 — existing dinners/grocery tabs UI to adapt
+- **Page data fetching:** `src/app/page.tsx` — `useState` + `useEffect` + `fetch` pattern with loading skeleton
+- **Navigation header:** `src/app/layout.tsx` lines 35-59 — sticky header with nav links
+- **Types:** `StoredMealPlan` in `src/lib/storage/types.ts`, `MealPlan` in `src/types/meal-plan.ts`
+
+## Key Technical Decisions
+
+- **Single page with expandable history** rather than separate `/plans/:id` routes — keeps it simple. The current plan is shown prominently at the top, past plans are collapsible cards below.
+
+- **New `GET /api/plans` endpoint** rather than fetching from the client via the storage layer directly — follows the existing API route pattern and works with auth.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Should the plans API require auth?** Yes — follow the same `requireAuth` pattern as other endpoints.
+- **Should past plans show full details or just summaries?** The API returns full plans. The UI shows summaries in the list with expandable details to avoid clutter.
+
+### Deferred to Implementation
+
+- Exact layout for the history list (cards vs table vs accordion)
+- Whether to use the same Tabs component from the generate page or a simpler layout
+
+## Implementation Units
+
+- [x] **Unit 1: Add GET /api/plans endpoint**
+
+**Goal:** Expose meal plan history via a list API.
+
+**Requirements:** R2
+
+**Dependencies:** None
+
+**Files:**
+- Create: `src/app/api/plans/route.ts`
+- Test: `src/app/api/plans/route.test.ts`
+
+**Approach:**
+- GET handler that calls `getMealPlanRepo().list(limit)` where `limit` comes from `?limit=` query param (default 10)
+- Use `requireAuth` from `src/lib/auth.ts`
+- Return JSON array of `StoredMealPlan` objects
+
+**Patterns to follow:**
+- `src/app/api/plan/current/route.ts` for route structure and auth pattern
+
+**Test scenarios:**
+- Happy path: Returns array of plans with 200
+- Happy path: Returns empty array when no plans exist
+- Happy path: `?limit=5` returns at most 5 plans
+- Happy path: Auth skipped when CRON_SECRET is empty
+- Error path: Returns 401 when CRON_SECRET is set and token is missing
+- Error path: Returns 500 on storage error
+
+**Verification:**
+- `GET /api/plans` returns a JSON array of stored meal plans
+
+- [x] **Unit 2: Create /plans page with current plan and history**
+
+**Goal:** Build the meal plan viewer page showing current plan and past plans.
+
+**Requirements:** R1, R2, R3, R5
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Create: `src/app/plans/page.tsx`
+
+**Approach:**
+- Client component that fetches both `GET /api/plan/current` and `GET /api/plans` on mount
+- Top section: current plan with dinners and grocery list (adapt the tabbed display from the generate page)
+- Bottom section: past plans listed by `weekOf` date with expandable details
+- Loading skeleton while fetching
+- Empty state if no plans have been generated yet
+- Include auth header handling (same localStorage secret pattern as generate page)
+
+**Patterns to follow:**
+- `src/app/generate/page.tsx` for plan display (dinners tab, grocery list tab)
+- `src/app/page.tsx` for data fetching and loading skeleton pattern
+
+**Test scenarios:**
+- Happy path: Current plan renders with dinners and grocery list
+- Happy path: Past plans render as a list with `weekOf` dates
+- Edge case: No plans exist — shows empty state message
+- Edge case: Only one plan (current) — no "past plans" section
+
+**Verification:**
+- `/plans` page loads, shows current plan prominently, and lists history below
+
+- [x] **Unit 3: Add Plans link to navigation header**
+
+**Goal:** Make the plans page discoverable from the main navigation.
+
+**Requirements:** R4
+
+**Dependencies:** Unit 2
+
+**Files:**
+- Modify: `src/app/layout.tsx`
+
+**Approach:**
+- Add a "Plans" or "Meal Plans" link to the header nav, between the existing "Generate Plan" and "Add Recipe" buttons
+- Use the same Button component with `variant="outline"` and a calendar icon (CalendarDays from lucide-react)
+
+**Patterns to follow:**
+- Existing nav links in `src/app/layout.tsx` (Generate Plan button pattern)
+
+**Test expectation:** none — pure navigation/styling change
+
+**Verification:**
+- Header shows a "Meal Plans" link that navigates to `/plans`
+
+## System-Wide Impact
+
+- **API surface:** One new endpoint (`GET /api/plans`) — read-only, auth-protected
+- **Navigation:** One new header link — no existing links affected
+- **Unchanged invariants:** Generate page, plan/current endpoint, recipe CRUD — all unchanged
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| No plans generated yet (new install) | Empty state UI with link to generate page |
+| Auth on plans endpoint blocks UI when CRON_SECRET is set | Same localStorage secret pattern as generate page |
+
+## Sources & References
+
+- Related issue: dancj/meal-assistant#9
+- Storage interface: `src/lib/storage/types.ts`
+- Plan display template: `src/app/generate/page.tsx`

--- a/docs/plans/2026-04-05-003-feat-resend-custom-domain-guide-plan.md
+++ b/docs/plans/2026-04-05-003-feat-resend-custom-domain-guide-plan.md
@@ -1,0 +1,85 @@
+---
+title: "feat: Add Resend custom domain setup guide"
+type: feat
+status: active
+date: 2026-04-05
+---
+
+# feat: Add Resend custom domain setup guide
+
+## Overview
+
+Write a setup guide explaining how to configure a custom domain in Resend so meal plan emails can be sent to all household members, not just the account owner.
+
+## Problem Frame
+
+Resend's free tier sends from `onboarding@resend.dev`, which only delivers to the account owner's email address. Users who want to email meal plans to other household members (spouse, roommates) need to verify a custom domain. The README mentions this in one line but doesn't walk through the process.
+
+Related: dancj/meal-assistant#20
+
+## Requirements Trace
+
+- R1. Step-by-step guide for verifying a custom domain in Resend
+- R2. Instructions for updating `EMAIL_FROM` and `EMAIL_RECIPIENTS` env vars
+- R3. Verification steps to confirm the setup works
+- R4. README references the guide
+
+## Scope Boundaries
+
+- No code changes — documentation only
+- No changes to the email implementation — it already supports custom domains and multiple recipients
+- No Resend API integration beyond what already exists
+
+## Key Technical Decisions
+
+- **Standalone guide in `docs/`** rather than expanding the README — keeps the README concise while providing detailed instructions for those who need them. Follows the pattern of `docs/api.md` and `docs/nanoclaw-setup.md`.
+
+## Implementation Units
+
+- [ ] **Unit 1: Write the custom domain guide**
+
+**Goal:** Create `docs/resend-custom-domain.md` with setup instructions.
+
+**Requirements:** R1, R2, R3
+
+**Dependencies:** None
+
+**Files:**
+- Create: `docs/resend-custom-domain.md`
+
+**Approach:**
+- Cover: why it's needed (free tier limitation), Resend dashboard steps (add domain, add DNS records, verify), updating env vars (`EMAIL_FROM` to custom domain address, `EMAIL_RECIPIENTS` to household members), testing via the generate page, troubleshooting common issues
+- Reference the existing env vars from `.env.example`
+- Link to Resend's official domain verification docs
+
+**Test expectation:** none — documentation only
+
+**Verification:**
+- `docs/resend-custom-domain.md` exists with clear, actionable steps
+
+- [ ] **Unit 2: Reference the guide from README**
+
+**Goal:** Update the README's Resend note to link to the new guide.
+
+**Requirements:** R4
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `README.md`
+
+**Approach:**
+- Update the existing note at the bottom of the README (currently links directly to Resend docs) to also link to the local guide
+- Keep it brief — one additional sentence or link
+
+**Test expectation:** none — documentation only
+
+**Verification:**
+- README links to `docs/resend-custom-domain.md`
+
+## Sources & References
+
+- Related issue: dancj/meal-assistant#20
+- Email implementation: `src/lib/email.ts`
+- Env vars: `.env.example`
+- Resend docs: https://resend.com/docs/dashboard/domains/introduction

--- a/src/app/api/plans/route.test.ts
+++ b/src/app/api/plans/route.test.ts
@@ -1,0 +1,97 @@
+import { GET } from "./route";
+
+const mockMealPlanRepo = {
+  save: vi.fn(),
+  getCurrent: vi.fn(),
+  list: vi.fn(),
+};
+
+vi.mock("@/lib/storage", () => ({
+  getMealPlanRepo: () => mockMealPlanRepo,
+}));
+
+const originalEnv = process.env;
+
+afterAll(() => {
+  process.env = originalEnv;
+});
+
+describe("GET /api/plans", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env = { ...originalEnv };
+    delete process.env.CRON_SECRET;
+  });
+
+  it("returns 200 with array of plans", async () => {
+    const plans = [
+      { id: "1", weekOf: "2026-04-07", dinners: [], groceryList: [], created_at: "2026-04-05" },
+      { id: "2", weekOf: "2026-03-31", dinners: [], groceryList: [], created_at: "2026-03-29" },
+    ];
+    mockMealPlanRepo.list.mockResolvedValue(plans);
+
+    const response = await GET(new Request("http://localhost/api/plans"));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual(plans);
+    expect(mockMealPlanRepo.list).toHaveBeenCalledWith(10);
+  });
+
+  it("returns 200 with empty array when no plans exist", async () => {
+    mockMealPlanRepo.list.mockResolvedValue([]);
+
+    const response = await GET(new Request("http://localhost/api/plans"));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual([]);
+  });
+
+  it("passes limit query param to repository", async () => {
+    mockMealPlanRepo.list.mockResolvedValue([]);
+
+    await GET(new Request("http://localhost/api/plans?limit=5"));
+
+    expect(mockMealPlanRepo.list).toHaveBeenCalledWith(5);
+  });
+
+  it("clamps limit to max 50", async () => {
+    mockMealPlanRepo.list.mockResolvedValue([]);
+
+    await GET(new Request("http://localhost/api/plans?limit=100"));
+
+    expect(mockMealPlanRepo.list).toHaveBeenCalledWith(50);
+  });
+
+  it("returns 401 when CRON_SECRET is set and no token provided", async () => {
+    process.env.CRON_SECRET = "test-secret";
+
+    const response = await GET(new Request("http://localhost/api/plans"));
+
+    expect(response.status).toBe(401);
+  });
+
+  it("returns 200 when CRON_SECRET is set and valid token provided", async () => {
+    process.env.CRON_SECRET = "test-secret";
+    mockMealPlanRepo.list.mockResolvedValue([]);
+
+    const response = await GET(
+      new Request("http://localhost/api/plans", {
+        headers: { Authorization: "Bearer test-secret" },
+      })
+    );
+
+    expect(response.status).toBe(200);
+  });
+
+  it("returns 500 on storage error", async () => {
+    mockMealPlanRepo.list.mockRejectedValue(new Error("db error"));
+
+    const response = await GET(new Request("http://localhost/api/plans"));
+    const body = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(body.error).toBe("Failed to fetch plans");
+  });
+});

--- a/src/app/api/plans/route.ts
+++ b/src/app/api/plans/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from "next/server";
+import { getMealPlanRepo } from "@/lib/storage";
+import { requireAuth } from "@/lib/auth";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(request: Request) {
+  const authError = requireAuth(request);
+  if (authError) return authError;
+
+  try {
+    const { searchParams } = new URL(request.url);
+    const limit = Math.min(
+      Math.max(parseInt(searchParams.get("limit") ?? "10") || 10, 1),
+      50
+    );
+    const plans = await getMealPlanRepo().list(limit);
+    return NextResponse.json(plans);
+  } catch (err) {
+    console.error("Failed to fetch plans:", err);
+    return NextResponse.json(
+      { error: "Failed to fetch plans" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import Link from "next/link";
-import { CalendarDays, Plus, UtensilsCrossed } from "lucide-react";
+import { CalendarDays, ClipboardList, Plus, UtensilsCrossed } from "lucide-react";
 import { Toaster } from "@/components/ui/sonner";
 import DemoBanner from "@/components/DemoBanner";
 import "./globals.css";
@@ -39,6 +39,14 @@ export default function RootLayout({
               Meal Assistant
             </Link>
             <div className="flex items-center gap-2">
+              <Link
+                href="/plans"
+                className="inline-flex shrink-0 items-center justify-center gap-1 rounded-lg border border-primary/20 text-primary h-7 px-2.5 text-[0.8rem] font-medium hover:bg-primary/5 transition-all"
+                data-testid="meal-plans-link"
+              >
+                <ClipboardList className="size-3.5" />
+                Meal Plans
+              </Link>
               <Link
                 href="/generate"
                 className="inline-flex shrink-0 items-center justify-center gap-1 rounded-lg border border-primary/20 text-primary h-7 px-2.5 text-[0.8rem] font-medium hover:bg-primary/5 transition-all"

--- a/src/app/plans/page.tsx
+++ b/src/app/plans/page.tsx
@@ -1,0 +1,237 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import {
+  CalendarDays,
+  ChevronDown,
+  ChevronUp,
+  ShoppingCart,
+  UtensilsCrossed,
+} from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Card } from "@/components/ui/card";
+import { Separator } from "@/components/ui/separator";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
+import type { StoredMealPlan } from "@/lib/storage/types";
+
+function PlanSkeleton() {
+  return (
+    <div className="space-y-6">
+      <Skeleton className="h-7 w-48" />
+      <div className="space-y-2">
+        {[1, 2, 3, 4, 5].map((i) => (
+          <Skeleton key={i} className="h-16 w-full rounded-lg" />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function PlanDisplay({ plan }: { plan: StoredMealPlan }) {
+  return (
+    <Tabs defaultValue="dinners">
+      <TabsList>
+        <TabsTrigger value="dinners">
+          <UtensilsCrossed className="size-4" />
+          Dinners
+        </TabsTrigger>
+        <TabsTrigger value="grocery-list">
+          <ShoppingCart className="size-4" />
+          Grocery List
+        </TabsTrigger>
+      </TabsList>
+
+      <TabsContent value="dinners">
+        <div className="space-y-2 pt-3">
+          {plan.dinners.map((dinner) => (
+            <div
+              key={dinner.day}
+              className="rounded-lg border bg-card p-4 flex items-start justify-between gap-3"
+            >
+              <div className="min-w-0">
+                <div className="flex items-center gap-2">
+                  <span className="text-xs font-medium text-muted-foreground uppercase tracking-wide w-24 shrink-0">
+                    {dinner.day}
+                  </span>
+                  <span className="font-medium">{dinner.recipeName}</span>
+                </div>
+                {dinner.alternativeNote && (
+                  <p className="text-xs text-muted-foreground mt-1 ml-26">
+                    {dinner.alternativeNote}
+                  </p>
+                )}
+              </div>
+              <span className="text-xs text-muted-foreground shrink-0">
+                {dinner.servings} servings
+              </span>
+            </div>
+          ))}
+        </div>
+      </TabsContent>
+
+      <TabsContent value="grocery-list">
+        <div className="pt-3">
+          <div className="rounded-lg border bg-card">
+            <ul className="divide-y">
+              {plan.groceryList.map((item, i) => (
+                <li
+                  key={i}
+                  className="px-4 py-2 flex items-center justify-between text-sm"
+                >
+                  <span>{item.item}</span>
+                  <span className="text-muted-foreground">{item.quantity}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      </TabsContent>
+    </Tabs>
+  );
+}
+
+function HistoryItem({ plan }: { plan: StoredMealPlan }) {
+  const [expanded, setExpanded] = useState(false);
+
+  return (
+    <Card className="p-4">
+      <button
+        onClick={() => setExpanded(!expanded)}
+        className="w-full flex items-center justify-between cursor-pointer"
+      >
+        <div className="flex items-center gap-2">
+          <CalendarDays className="size-4 text-muted-foreground" />
+          <span className="font-medium">Week of {plan.weekOf}</span>
+          <span className="text-xs text-muted-foreground">
+            {plan.dinners.map((d) => d.recipeName).join(", ")}
+          </span>
+        </div>
+        {expanded ? (
+          <ChevronUp className="size-4 text-muted-foreground" />
+        ) : (
+          <ChevronDown className="size-4 text-muted-foreground" />
+        )}
+      </button>
+      {expanded && (
+        <div className="mt-4">
+          <PlanDisplay plan={plan} />
+        </div>
+      )}
+    </Card>
+  );
+}
+
+export default function PlansPage() {
+  const [currentPlan, setCurrentPlan] = useState<StoredMealPlan | null>(null);
+  const [pastPlans, setPastPlans] = useState<StoredMealPlan[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const secret = localStorage.getItem("meal-assistant-secret");
+        const headers: Record<string, string> = {};
+        if (secret) {
+          headers["Authorization"] = `Bearer ${secret}`;
+        }
+
+        const [currentRes, historyRes] = await Promise.all([
+          fetch("/api/plan/current", { headers }),
+          fetch("/api/plans", { headers }),
+        ]);
+
+        let current: StoredMealPlan | null = null;
+        if (currentRes.ok) {
+          current = await currentRes.json();
+          setCurrentPlan(current);
+        }
+
+        if (historyRes.ok) {
+          const allPlans: StoredMealPlan[] = await historyRes.json();
+          setPastPlans(
+            current ? allPlans.filter((p) => p.id !== current.id) : allPlans
+          );
+        }
+      } catch {
+        setError("Failed to load meal plans");
+      } finally {
+        setLoading(false);
+      }
+    }
+    load();
+  }, []);
+
+  if (loading) {
+    return <PlanSkeleton />;
+  }
+
+  if (error) {
+    return (
+      <div className="rounded-lg border border-destructive/20 bg-destructive/10 text-destructive p-4 text-sm">
+        {error}
+      </div>
+    );
+  }
+
+  if (!currentPlan && pastPlans.length === 0) {
+    return (
+      <div className="text-center py-20">
+        <CalendarDays className="size-12 text-primary/30 mx-auto mb-4" />
+        <p className="text-lg text-muted-foreground mb-2">No meal plans yet</p>
+        <p className="text-sm text-muted-foreground/70 mb-6">
+          Generate your first meal plan to see it here.
+        </p>
+        <Link
+          href="/generate"
+          className="text-primary hover:underline font-medium text-sm"
+        >
+          Generate a plan &rarr;
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold">Meal Plans</h1>
+        <p className="text-muted-foreground mt-1">
+          View your current and past weekly meal plans.
+        </p>
+      </div>
+
+      {currentPlan && (
+        <div className="space-y-4">
+          <div className="flex items-center gap-2">
+            <Badge variant="outline">
+              Week of {currentPlan.weekOf}
+            </Badge>
+            <Badge variant="secondary" className="bg-primary/10 text-primary">
+              Current
+            </Badge>
+          </div>
+          <PlanDisplay plan={currentPlan} />
+        </div>
+      )}
+
+      {pastPlans.length > 0 && (
+        <>
+          <Separator />
+          <div className="space-y-3">
+            <h2 className="text-lg font-semibold text-muted-foreground">
+              Past Plans
+            </h2>
+            <div className="space-y-2">
+              {pastPlans.map((plan) => (
+                <HistoryItem key={plan.id} plan={plan} />
+              ))}
+            </div>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Closes #9

Adds a `/plans` page for viewing the current meal plan and browsing past plans:

- **New `GET /api/plans` endpoint** — exposes `MealPlanRepository.list()` with optional `?limit=` param (default 10, max 50), auth-protected
- **`/plans` page** — current plan shown prominently with dinners/grocery tabs, past plans as expandable cards
- **Navigation link** — "Meal Plans" added to header between logo and Generate Plan

## Key decisions

- Expandable history cards rather than separate `/plans/:id` routes — keeps navigation simple
- Reused the same dinners/grocery tab layout from the generate page for consistency
- Past plans show recipe names in the collapsed summary for quick scanning

## Test plan

- [x] 124 tests pass (7 new for plans API)
- [x] Build passes
- [x] `/plans` shows current plan with dinners and grocery list
- [x] Past plans expand/collapse with full details
- [x] Empty state shows when no plans exist with link to generate
- [x] Auth handled via localStorage secret (same pattern as generate page)

## Post-Deploy Monitoring & Validation

No additional operational monitoring required — read-only page consuming existing storage layer. No new data writes, no external service calls.