### PR TITLE
feat(recipes): GET /api/recipes backed by private GitHub repo (#64)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,8 @@
+# GitHub recipe store (#64) — required for /api/recipes
+GITHUB_PAT=your-github-pat
+RECIPES_REPO=your-username/your-recipes
+RECIPES_PATH=recipes
+
 # Resend (optional — only needed if email delivery is enabled via #70)
 RESEND_API_KEY=your-resend-api-key
 EMAIL_FROM=onboarding@resend.dev

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,9 +30,9 @@ Do not reintroduce Supabase, SQLite, `better-sqlite3`, `@google/genai`, or the w
 ### Source Layout
 
 All source code lives under `src/`:
-- `src/app/` — pages, layouts, and future API routes (`src/app/api/[route]/route.ts`)
+- `src/app/` — pages, layouts, and API routes (`src/app/api/[route]/route.ts`). Implemented routes: `GET /api/recipes` (#64).
 - `src/components/` — UI components (shadcn primitives under `src/components/ui/`)
-- `src/lib/` — shared utilities. Currently: `resend.ts` (lazy Resend client factory, retained for #70), `email.ts` (`parseRecipients` helper), `utils.ts` (`cn` className merger)
+- `src/lib/` — shared utilities. Currently: `recipes/` (GitHub-backed recipe reader — `types.ts`, `parse.ts`, `github.ts`), `resend.ts` (lazy Resend client factory, retained for #70), `email.ts` (`parseRecipients` helper), `utils.ts` (`cn` className merger)
 - `src/test/` — Vitest setup
 - `docs/plans/` — dated implementation plans
 - `docs/brainstorms/` — requirements / discovery docs
@@ -45,7 +45,7 @@ Feature-specific directories (`src/types/`, `src/lib/storage/`, etc.) will be re
 
 The new stack is being built feature-by-feature. Each open issue owns its own endpoint, env vars, types, and docs:
 
-- **#64** — `/api/recipes`: read markdown recipes from a private GitHub repo (`GITHUB_PAT`, `RECIPES_REPO`, `RECIPES_PATH`)
+- **#64** — `/api/recipes`: reads markdown recipes from a private GitHub repo (`GITHUB_PAT`, `RECIPES_REPO`, `RECIPES_PATH`). **Implemented.** Recipe logic lives in `src/lib/recipes/` (pure parser + fetcher); the route is a thin error-mapping layer. Recipes are non-recursive — one directory depth, `.md` files only, dotfiles filtered.
 - **#65** — `/api/deals`: Safeway + Aldi deals via Flipp backend (`SAFEWAY_ZIP`, `ALDI_ZIP`)
 - **#66** — `/api/generate-plan`: Claude-powered plan generation with store context (`ANTHROPIC_API_KEY`)
 - **#67** — Single-page UI: deals sidebar, 5 meal cards, store-grouped grocery list
@@ -57,4 +57,11 @@ When starting work, check the relevant issue for its shape contracts (recipe sch
 
 ### Environment Variables
 
-See `.env.example`. Currently only `RESEND_*` keys are listed (and they are only consumed once #70 lands). Each feature issue adds the env vars it consumes in the same PR that introduces the consumer.
+See `.env.example`. Currently in use:
+
+- `GITHUB_PAT` (required by `/api/recipes`) — fine-grained PAT with Contents: Read scope on the recipes repo. Never interpolate its value into error messages.
+- `RECIPES_REPO` (required by `/api/recipes`) — `owner/name`, e.g. `your-username/your-recipes`.
+- `RECIPES_PATH` (required by `/api/recipes`) — directory inside the repo; empty string means repo root. Non-recursive.
+- `RESEND_*` — listed but not consumed until #70 adds `/api/email`.
+
+Each future feature issue adds the env vars it consumes in the same PR that introduces the consumer.

--- a/docs/plans/2026-04-23-001-feat-github-recipes-api-plan.md
+++ b/docs/plans/2026-04-23-001-feat-github-recipes-api-plan.md
@@ -1,0 +1,415 @@
+---
+title: "feat: GitHub recipe reader (/api/recipes backed by private repo markdown)"
+type: feat
+status: active
+date: 2026-04-23
+origin: https://github.com/dancj/meal-assistant/issues/64
+---
+
+# feat: GitHub recipe reader (/api/recipes backed by private repo markdown)
+
+## Overview
+
+First feature landing on the post-strip base. Implements `GET /api/recipes`, which reads markdown recipe files from a private GitHub repo (configured via env vars), parses frontmatter with `gray-matter`, and returns `Recipe[]`. This replaces the deleted Supabase recipe store and becomes the data source for the meal-plan generator (#66), the UI (#67), and the pantry-awareness filter (#69).
+
+---
+
+## Problem Frame
+
+The new stack keeps recipes in a user-owned private GitHub repo as markdown files — each recipe is a standalone, human-editable `.md` with YAML frontmatter. This is a deliberate shift away from a database: recipes should be portable, grep-able, diffable, and edited in any editor. The trade-off is that the app needs a read path that walks a GitHub directory, parses each file, and assembles a normalized shape.
+
+The feature is bounded by issue #64's explicit contract: one `GET` endpoint, one `Recipe` interface, three env vars, and a fixed set of failure modes. No pagination, no mutation, no caching — those stay out until downstream features need them.
+
+Origin issue: https://github.com/dancj/meal-assistant/issues/64
+
+---
+
+## Requirements Trace
+
+- R1. `GET /api/recipes` returns a JSON array of `Recipe` objects parsed from the markdown files in `RECIPES_PATH` inside `RECIPES_REPO`.
+- R2. `Recipe` has exactly: `title: string`, `tags: string[]`, `kidVersion: string | null`, `content: string`, `filename: string` (matching the issue's declared shape).
+- R3. `kidVersion` is populated from frontmatter key `kid_version`; when the key is absent, `kidVersion` is `null` (not omitted, not `undefined`).
+- R4. `content` is the markdown body **after** the frontmatter block (what `gray-matter` returns as `content`), not the raw file.
+- R5. `filename` is the basename of the source file (e.g., `chicken-tacos.md`), taken from the GitHub contents listing.
+- R6. Directory traversal is non-recursive and ignores anything that is not a regular file ending in `.md`. Subdirectories, symlinks, images, `README.md`-style non-recipes, and dotfiles are skipped.
+- R7. Env-var errors surface as HTTP 500 with a clear message naming the missing variable (`GITHUB_PAT`, `RECIPES_REPO`, or `RECIPES_PATH`).
+- R8. Upstream GitHub errors surface as HTTP 502 with a clear message distinguishing (a) auth failure (401/403), (b) repo/path not found (404), and (c) any other non-2xx response.
+- R9. A recipe file with missing `title` frontmatter — or frontmatter where `tags` exists but is not an array — surfaces as HTTP 502 and names the offending filename in the error, rather than being silently dropped.
+- R10. `.env.example` advertises the three new env vars (`GITHUB_PAT`, `RECIPES_REPO`, `RECIPES_PATH`) with safe placeholder values and a one-line description.
+- R11. `CLAUDE.md`'s "Active Work" list for #64 continues to point at this endpoint and the env vars remain accurate after merge.
+- R12. `npm run lint`, `npm test`, `npx tsc --noEmit`, and `npm run build` all succeed.
+
+---
+
+## Scope Boundaries
+
+- No caching layer, no ETag support, no revalidation strategy. Each request fetches fresh from GitHub.
+- No write path (`POST`/`PUT`/`DELETE`). Recipe authoring happens by editing the private repo directly; #68 will add a separate log-writer endpoint that's orthogonal.
+- No pagination or filtering query params. The endpoint returns the full list; filtering by tag/search lands with the UI (#67) or the generator (#66), client-side.
+- No recursive directory walking. Recipes live at one path depth; subdirectories are ignored rather than traversed.
+- No auth on the `/api/recipes` endpoint itself. The app is single-household; any protection added later belongs at the Vercel/deployment layer, not in this route. The old `CRON_SECRET` bearer check is explicitly not reintroduced.
+- No support for recipe-image assets stored alongside the markdown. Frontmatter may reference images via URL, but this endpoint does not fetch or inline them.
+- No SWR/React-Query client-side data hook — that lands with the UI (#67).
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- **Route convention.** Next.js 15 App Router: routes live at `src/app/api/<name>/route.ts` and export named HTTP verb handlers (`export async function GET(request: Request)`). No current routes exist after the strip, so this route establishes the in-repo pattern. Use `NextResponse.json(...)` (or plain `Response.json(...)`) with explicit status codes for errors.
+- **Lib structure.** `src/lib/` currently holds small single-responsibility modules (`email.ts`, `resend.ts`, `utils.ts`). Follow that style: colocate the recipe module under `src/lib/recipes/` as a small cluster (`types.ts`, `parse.ts`, `github.ts`) so pure parsing and side-effectful fetching are separately testable.
+- **Test conventions.** `src/lib/email.test.ts` is the template: Vitest `describe`/`it`, `expect(...).toEqual(...)` / `.toThrow(...)`, no mocks required for pure functions. `vitest.config.ts` runs under `environment: "node"`, which means `fetch` is the platform global — no `jsdom` involvement on the server tests.
+- **Strict-mode TS + test exclusion.** `tsconfig.json` has `strict: true` and excludes `**/*.test.ts` from the build. The production bundle sees only the non-test code; tests can import implementation freely via `@/*` alias.
+- **Env-var access pattern.** `src/lib/resend.ts` demonstrates the "read `process.env.X` lazily and throw a clear `Error` with the var name if missing" pattern. Reuse that for `GITHUB_PAT`/`RECIPES_REPO`/`RECIPES_PATH`.
+- **No existing HTTP client wrapper.** Nothing in `src/lib/` wraps `fetch`. Use `fetch` directly — a thin helper in `src/lib/recipes/github.ts` for building the authenticated request is sufficient.
+
+### Institutional Learnings
+
+- `~/.claude/projects/-Users-developer-projects-meal-assistant/memory/feedback_no_pii_in_public_repo.md`: `.env.example` and docs must use placeholder values (`your-username/your-recipes`, `your-github-pat`), never personal identifiers. Apply when writing U1 and U5.
+- `docs/plans/2026-04-22-001-refactor-strip-old-stack-plan.md`: the strip plan explicitly deferred new env vars to "the feature that consumes them." This plan is the first consumer; it owns adding `GITHUB_PAT`, `RECIPES_REPO`, `RECIPES_PATH`.
+- `docs/plans/2026-04-22-002-refactor-post-strip-residuals-plan.md`: the residuals plan established the convention that `CLAUDE.md` lists each open issue with its endpoint + env vars. Keeping that list accurate is explicitly in scope (R11) so future agents have a current map.
+
+### External References
+
+- GitHub REST API — Get repository content: https://docs.github.com/en/rest/repos/contents (directory response shape + per-file response with `Accept: application/vnd.github.raw` for raw bytes on private repos).
+- `gray-matter` (YAML frontmatter parser): https://github.com/jonschlinkert/gray-matter — returns `{ data, content, excerpt }`. `data.tags` is whatever YAML produced (array, string, undefined).
+- GitHub PAT rate limits: 5000 requests/hour for authenticated requests. A household-sized recipe collection (<100 files) issues ≤100 requests per page load; well under the ceiling.
+
+---
+
+## Key Technical Decisions
+
+- **Two-step fetch via the Contents API, not raw.githubusercontent.com.** For private repos, raw GitHub URLs require token-as-query-param auth (brittle) or fail outright. The Contents API accepts a Bearer PAT header, returns a JSON directory listing at a path, and — with `Accept: application/vnd.github.raw` — returns raw file bytes for a file path. Use the same auth + base URL for both steps; avoid any token-in-URL pattern.
+- **Parallel per-file fetches after the listing.** Once the directory listing is in hand, fetch all recipe files concurrently with `Promise.all`. Sequential fetching would multiply latency by N with no benefit; the GitHub API happily serves parallel authenticated requests well under the rate limit.
+- **Fail loud on malformed recipes.** If any file is missing `title` frontmatter or has non-array `tags`, fail the entire request with a 502 that names the bad filename. Silently skipping would mask user error; #64's "done when" includes "errors surface clearly." Partial success is worse than no success for debugging.
+- **Split parsing from fetching.** `src/lib/recipes/parse.ts` is a pure function (`string → Recipe` minus `filename`). `src/lib/recipes/github.ts` does all I/O. The route handler composes the two. This keeps the parser trivially testable with inline fixture strings and the fetcher testable with stubbed `fetch`.
+- **Route handler stays thin.** `src/app/api/recipes/route.ts` only: reads env, calls `fetchRecipesFromGitHub`, catches known error classes, shapes the response. All recipe logic lives in `src/lib/recipes/`.
+- **Named error classes for mapping.** Throw a small set of named `Error` subclasses from `github.ts` (`MissingEnvVarError`, `GitHubAuthError`, `GitHubNotFoundError`, `GitHubUpstreamError`, `RecipeParseError`). The route handler uses `instanceof` to map each to the right HTTP status. This avoids string-matching error messages or leaking stack traces.
+- **Non-recursive, .md-only, file-type-only.** Directory listings include `type: "dir" | "file" | "symlink" | "submodule"`. Accept only `type === "file"` whose `name` ends in `.md` and does not start with `.`. Everything else is silently filtered from the listing — that filter is not a user error, it's just "these aren't recipes."
+- **Path normalization.** `RECIPES_PATH` is trimmed and stripped of leading/trailing slashes before being interpolated into the URL. Allow an empty string to mean "repo root" but require the env var to be *set* (even if empty) so "missing env" stays distinct from "root path."
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Which API shape — Contents API, Git Trees API, or download URLs?** Contents API for both list and file, with the raw Accept header for files. Trees API adds complexity (SHAs, recursion) with no payoff for one flat directory; `download_url` returns a raw.githubusercontent.com link that doesn't authenticate cleanly against private repos.
+- **Should malformed recipes be skipped or fail the request?** Fail (see Key Decisions). Matches the issue's "errors surface clearly" requirement and prevents silent data loss.
+- **Is `RECIPES_PATH` required, optional, or defaulted?** Required env var (must be set). Allowed to be empty string for "repo root." Keeps "misconfigured" (missing) distinct from "configured to root" (set and empty).
+- **How to represent `kidVersion` when absent?** Explicit `null`, not `undefined` or omitted. The issue declares `kidVersion: string | null`; matching that exactly avoids JSON-serialization ambiguity downstream.
+- **Runtime: Node or Edge?** Node. Default Next.js App Router runtime. Edge adds no benefit here (no geographic pinning need) and limits some native APIs; Node is the simpler default and matches the Vitest `environment: "node"` test runtime.
+
+### Deferred to Implementation
+
+- **Exact ESM vs CJS interop for `gray-matter`.** `gray-matter` publishes CJS primarily. Next.js handles interop, but if `import matter from "gray-matter"` fails under strict TS settings, fall back to `import * as matter from "gray-matter"` or tweak the import. Decide once the code touches it.
+- **Vercel edge caching headers.** Whether to set `Cache-Control: private, max-age=...` on the response is a rollout/tuning question. For now the route returns fresh data every call; revisit once deploy lands and there's a latency measurement.
+
+---
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Client as Client (browser or agent)
+    participant Route as GET /api/recipes<br/>src/app/api/recipes/route.ts
+    participant GH as src/lib/recipes/github.ts
+    participant Parse as src/lib/recipes/parse.ts
+    participant API as GitHub Contents API
+
+    Client->>Route: GET /api/recipes
+    Route->>GH: fetchRecipesFromGitHub()
+    GH->>GH: read + validate env vars<br/>(throw MissingEnvVarError on gap)
+    GH->>API: GET /repos/{owner}/{repo}/contents/{path}<br/>Authorization: Bearer PAT
+    API-->>GH: directory listing JSON
+    GH->>GH: filter to regular .md files
+    par for each recipe file
+        GH->>API: GET /repos/.../contents/{path}/{name}<br/>Accept: application/vnd.github.raw
+        API-->>GH: raw markdown bytes
+        GH->>Parse: parseRecipeMarkdown(text, filename)
+        Parse-->>GH: Recipe (throws RecipeParseError on bad frontmatter)
+    end
+    GH-->>Route: Recipe[]
+    Route-->>Client: 200 JSON Recipe[]
+
+    alt env var missing
+        Route-->>Client: 500 { error: "X env var is required" }
+    else GitHub 401/403
+        Route-->>Client: 502 { error: "GitHub auth failed (check GITHUB_PAT)" }
+    else GitHub 404
+        Route-->>Client: 502 { error: "Repo or path not found (check RECIPES_REPO/RECIPES_PATH)" }
+    else recipe parse failure
+        Route-->>Client: 502 { error: "Failed to parse <filename>: ..." }
+    end
+```
+
+The diagram names shape; specific signatures and error-class layouts are implementation choices.
+
+---
+
+## Implementation Units
+
+- [ ] U1. **Scaffolding: Recipe type, gray-matter dependency, env-example additions**
+
+**Goal:** Put the three pieces of scaffolding in place that every later unit depends on. No behavior yet — just the type, the library, and the declared env contract.
+
+**Requirements:** R2, R3, R10
+
+**Dependencies:** None
+
+**Files:**
+- Create: `src/lib/recipes/types.ts`
+- Modify: `package.json` (add `gray-matter` to `dependencies`)
+- Modify: `package-lock.json` (as a side effect of `npm install`)
+- Modify: `.env.example`
+
+**Approach:**
+- `src/lib/recipes/types.ts` exports a `Recipe` interface matching the issue's shape exactly: `title: string`, `tags: string[]`, `kidVersion: string | null`, `content: string`, `filename: string`. No extra fields. No optional fields — callers should not have to handle `undefined` where the issue promises `null`.
+- Add `gray-matter` via `npm install gray-matter`. Also add `@types/gray-matter` only if `gray-matter` does not ship its own types (check on install).
+- `.env.example` gains three entries grouped under a `# GitHub recipe store (#64)` comment: `GITHUB_PAT=your-github-pat`, `RECIPES_REPO=your-username/your-recipes`, `RECIPES_PATH=recipes`. Use generic placeholder values per the public-repo-generic learning.
+
+**Patterns to follow:**
+- `.env.example`'s existing `# Resend (optional — only needed if email delivery is enabled via #70)` comment style.
+- `src/lib/utils.ts` — single-file, single-purpose module in `src/lib/`.
+
+**Test scenarios:**
+- Test expectation: none — this unit only installs a dependency, declares a type, and adds env placeholders. No runtime behavior is introduced. U2 and U3 exercise the Recipe shape via real parsing/fetching.
+
+**Verification:**
+- `src/lib/recipes/types.ts` exists and exports `Recipe` with the five fields in the exact types the issue declares.
+- `npm ls gray-matter` shows the package installed.
+- `.env.example` contains all three new keys with placeholder values; no personal identifiers.
+- `npm run build` succeeds (confirms the new type file compiles under strict TS).
+
+---
+
+- [ ] U2. **Pure parser: `parseRecipeMarkdown(source, filename)`**
+
+**Goal:** A pure function that takes a markdown string and a filename, parses frontmatter with `gray-matter`, and returns a `Recipe`. No I/O, no env reads, no globals. Throws a named `RecipeParseError` for malformed input.
+
+**Requirements:** R2, R3, R4, R9
+
+**Dependencies:** U1
+
+**Files:**
+- Create: `src/lib/recipes/parse.ts`
+- Create: `src/lib/recipes/parse.test.ts`
+- Modify: `src/lib/recipes/types.ts` (add `RecipeParseError` class export, unless placed in a separate `errors.ts` — implementer's call)
+
+**Approach:**
+- Signature: takes the raw markdown `source` (string) and `filename` (string), returns `Recipe`.
+- Calls `gray-matter` once. From the result's `data`:
+  - `title`: required string; throw `RecipeParseError` if missing, empty, or not a string.
+  - `tags`: if absent → `[]`. If present and an array of strings → use as-is. If present and not an array, or not all strings → throw `RecipeParseError`.
+  - `kid_version`: optional; if present must be a non-empty string, mapped to `kidVersion`; if absent → `null`.
+- `content`: `gray-matter`'s `.content` field (post-frontmatter body), trimmed of leading whitespace but preserving interior formatting.
+- `filename`: passed through from the argument. The parser never reads from disk or URL — it is told what file it's representing.
+- `RecipeParseError` subclasses `Error`, carries `filename` and original `message`, and prefixes its `.message` with the filename (`"chicken-tacos.md: title frontmatter is required"`).
+
+**Execution note:** Implement test-first. The parser has a tight contract with many small branches; a failing-test-first pass catches off-by-one frontmatter cases early.
+
+**Patterns to follow:**
+- `src/lib/email.ts#parseRecipients`: small, pure, throws `Error` with a clear message; no global state. Keep `parse.ts` in that spirit.
+
+**Test scenarios:**
+- Happy path: full frontmatter (title, tags array, kid_version) + body → `Recipe` with all fields populated; `kidVersion` matches the string.
+- Happy path: frontmatter with only `title` and `tags` (no `kid_version` key at all) → `Recipe` with `kidVersion: null` and the right tags array.
+- Happy path: frontmatter with `kid_version:` present but with no value (YAML parses this as `null`) → `Recipe` with `kidVersion: null`. Treated the same as "key absent."
+- Happy path: frontmatter with `title` only, no `tags` key → `Recipe` with `tags: []`, `kidVersion: null`.
+- Edge case: `tags: []` explicitly → `Recipe` with empty array (not `null`, not missing).
+- Edge case: body contains multiple `---` lines after the frontmatter block → `content` preserves those; only the leading YAML block is stripped.
+- Edge case: frontmatter with CRLF line endings → parses correctly (gray-matter handles this, but cover it so a future library swap doesn't regress).
+- Edge case: `kid_version: ""` (empty string) → throws `RecipeParseError` (explicit empty is user error; use the key or omit it).
+- Error path: missing frontmatter block entirely → throws `RecipeParseError` naming missing `title`.
+- Error path: frontmatter present but no `title` key → throws `RecipeParseError` naming the filename.
+- Error path: `title` not a string (e.g., number) → throws `RecipeParseError`.
+- Error path: `tags` not an array (e.g., a string `"quick, mexican"`) → throws `RecipeParseError`. YAML coerces easily; the error must fire so users fix their file.
+- Error path: `tags` is an array containing non-strings (e.g., `[1, 2]`) → throws `RecipeParseError`.
+- Error path: `RecipeParseError.message` begins with the passed `filename`.
+
+**Verification:**
+- `parseRecipeMarkdown` is exported from `src/lib/recipes/parse.ts` and importable via `@/lib/recipes/parse`.
+- All test scenarios above pass.
+- `npx tsc --noEmit` clean — the function's signature is fully typed without `any`.
+
+---
+
+- [ ] U3. **GitHub fetcher: `fetchRecipesFromGitHub()`**
+
+**Goal:** The side-effectful function that reads env, talks to GitHub, composes with the parser, and returns `Recipe[]`. Throws named errors for each failure class so the route handler can map them to HTTP status codes.
+
+**Requirements:** R1, R5, R6, R7, R8, R9
+
+**Dependencies:** U1, U2
+
+**Files:**
+- Create: `src/lib/recipes/github.ts`
+- Create: `src/lib/recipes/github.test.ts`
+- Modify: `src/lib/recipes/types.ts` (add error classes `MissingEnvVarError`, `GitHubAuthError`, `GitHubNotFoundError`, `GitHubUpstreamError` — or in a sibling `errors.ts`)
+
+**Approach:**
+- Signature: takes no arguments, returns `Promise<Recipe[]>`. Reads env at call time (not module load) so tests can stub it per-case.
+- Env validation: read `GITHUB_PAT`, `RECIPES_REPO`, `RECIPES_PATH`. If any is `undefined` or `null` (but not empty string for `RECIPES_PATH`), throw `MissingEnvVarError` naming the var.
+- URL construction: base `https://api.github.com/repos/${RECIPES_REPO}/contents/${normalizedPath}`. Normalize the path by trimming and stripping leading/trailing `/`.
+- Listing request: GET with headers `Authorization: Bearer ${GITHUB_PAT}`, `Accept: application/vnd.github+json`, `X-GitHub-Api-Version: 2022-11-28`, and a descriptive `User-Agent: meal-assistant`.
+  - Status 401/403 → `GitHubAuthError`.
+  - Status 404 → `GitHubNotFoundError`.
+  - Any other non-2xx → `GitHubUpstreamError` with the status code in the message.
+- Filter listing: keep only entries where `type === "file"`, `name.endsWith(".md")`, and `!name.startsWith(".")`.
+- Per-file fetch: for each kept entry, GET the file's Contents API URL using the `url` field from the listing item (always present on Contents API directory responses — already URL-encoded by GitHub, so no client-side encoding needed) with `Accept: application/vnd.github.raw` + the same auth header. Same error mapping as listing, except a per-file 404 is still `GitHubUpstreamError` (listing promised this file; a mid-flight 404 is an upstream anomaly, not a config error).
+- Fetches run in parallel via `Promise.all`. If any file throws, the whole call rejects — no partial results.
+- Each raw body goes through `parseRecipeMarkdown(text, entry.name)`. Parser errors propagate as-is (they're already `RecipeParseError`).
+
+**Patterns to follow:**
+- `src/lib/resend.ts`: lazy env read + throw a clear named error with the env var name when missing. Mirror the shape, with the richer error class for this domain.
+
+**Test scenarios:**
+- Happy path: stub `fetch` to return a 2-file directory listing then two raw markdowns → returns an array of two `Recipe` objects in order; each has the correct `filename`.
+- Happy path: directory listing includes a mix (a regular `.md` file, a subdirectory whose *name* happens to end in `.md` but has `type: "dir"`, a `.jpg` file, and a `README.md` file) → only regular files ending in `.md` are fetched. The `.md`-named subdirectory is filtered out by `type === "file"`, not by its name. A `README.md` *is* fetched and treated as a recipe; if the user puts one in the recipes folder they should expect it to be parsed (document this in CLAUDE.md as a convention).
+- Edge case: empty directory listing → returns `[]` without making per-file requests.
+- Edge case: `RECIPES_PATH` is `""` (empty string) → URL built as `/repos/owner/repo/contents/` (trailing slash acceptable) and request is made against repo root.
+- Edge case: `RECIPES_PATH` is `"recipes/"` (trailing slash) → normalized to `recipes` in the URL.
+- Edge case: directory has 20 files → all 20 are fetched concurrently (verify via mock that all fetch calls happen before the first resolves).
+- Error path: `GITHUB_PAT` is undefined → throws `MissingEnvVarError` with message including `"GITHUB_PAT"`.
+- Error path: `RECIPES_REPO` is undefined → throws `MissingEnvVarError` with message including `"RECIPES_REPO"`.
+- Error path: `RECIPES_PATH` is undefined → throws `MissingEnvVarError` with message including `"RECIPES_PATH"`.
+- Error path: listing request returns 401 → throws `GitHubAuthError`.
+- Error path: listing request returns 403 → throws `GitHubAuthError`.
+- Error path: listing request returns 404 → throws `GitHubNotFoundError`.
+- Error path: listing request returns 500 → throws `GitHubUpstreamError` with `"500"` in the message.
+- Error path: per-file request returns 404 mid-flight (after listing succeeded) → throws `GitHubUpstreamError`, not `GitHubNotFoundError` (reserving `GitHubNotFoundError` for the config-level "repo or path doesn't exist" case).
+- Error path: per-file content has invalid frontmatter → throws `RecipeParseError` from U2; the filename is in the message.
+- Integration: `fetchRecipesFromGitHub` composes `parseRecipeMarkdown` on real raw bytes (no parser mock). Stubbing only `fetch` ensures the listing→parse chain is exercised end-to-end inside `github.ts`.
+
+**Verification:**
+- `fetchRecipesFromGitHub` is exported and returns typed `Promise<Recipe[]>`.
+- All test scenarios above pass.
+- Error classes are exported and each test asserts `instanceof` the specific class (not just `Error`).
+- `npx tsc --noEmit` clean.
+
+---
+
+- [ ] U4. **Route handler: `GET /api/recipes`**
+
+**Goal:** The thin HTTP layer. Calls `fetchRecipesFromGitHub`, maps each named error class to the right status code, returns JSON.
+
+**Requirements:** R1, R7, R8
+
+**Dependencies:** U3
+
+**Files:**
+- Create: `src/app/api/recipes/route.ts`
+- Create: `src/app/api/recipes/route.test.ts`
+
+**Approach:**
+- Export `async function GET()` — no `request` parameter needed for now (no query params in scope).
+- `try { const recipes = await fetchRecipesFromGitHub(); return Response.json(recipes); } catch (err) { ... }`.
+- Error mapping in the catch:
+  - `MissingEnvVarError` → 500 with `{ error: err.message }`.
+  - `GitHubAuthError` → 502 with `{ error: "GitHub auth failed (check GITHUB_PAT)" }`.
+  - `GitHubNotFoundError` → 502 with `{ error: "Repo or path not found, or PAT lacks access — check RECIPES_REPO, RECIPES_PATH, and GITHUB_PAT scope" }`. GitHub returns 404 both for "this resource doesn't exist" and for "this resource exists but your PAT can't see it" (it refuses to leak private-repo existence). The message must mention all three env vars so the user has all three knobs to check.
+  - `GitHubUpstreamError` → 502 with `{ error: "GitHub upstream error: <original message>" }`.
+  - `RecipeParseError` → 502 with `{ error: "Failed to parse <filename>: <detail>" }` — the parser already prefixes the filename, so passing `err.message` is enough.
+  - Any other `Error` → 500 with `{ error: "Unexpected error fetching recipes" }`. Log the real error server-side; don't leak it to the client.
+- Explicit `export const runtime = "nodejs";` — locks the runtime so a future Next default change doesn't silently move this to Edge.
+- Do not set cache headers (deferred per Open Questions).
+
+**Patterns to follow:**
+- Next.js App Router route handler conventions. No existing in-repo example; follow the Next.js docs pattern for a GET-only resource route.
+
+**Test scenarios:**
+- Happy path: stub `fetchRecipesFromGitHub` to resolve with two recipes → `GET` handler returns a `Response` with status 200, JSON body equal to the recipes array.
+- Error path: `MissingEnvVarError` → response status 500, body `{ error: <message> }`.
+- Error path: `GitHubAuthError` → response status 502, body includes `"GITHUB_PAT"`.
+- Error path: `GitHubNotFoundError` → response status 502, body includes `"RECIPES_REPO"`, `"RECIPES_PATH"`, and `"GITHUB_PAT"` (GitHub's 404 is ambiguous between "missing" and "no access", so all three need naming).
+- Error path: `GitHubUpstreamError` → response status 502, body includes `"upstream"`.
+- Error path: `RecipeParseError` for `chicken-tacos.md` → response status 502, body includes `"chicken-tacos.md"`.
+- Error path: an unexpected `TypeError` thrown by the fetcher → response status 500, body is the generic message, and the real error is not leaked in the response body.
+- Integration: route.test.ts stubs only `fetchRecipesFromGitHub` (not `fetch` itself). This keeps the route test focused on HTTP-layer mapping, not transport.
+
+**Verification:**
+- `src/app/api/recipes/route.ts` exports a `GET` async function and a `runtime = "nodejs"` const.
+- All test scenarios above pass.
+- Starting the dev server with all three env vars set (to a real or fake repo) returns a response for `curl http://localhost:3000/api/recipes`; with any env var missing the response is a 500 with a clear message.
+- `npm run build` succeeds and reports the `/api/recipes` route in the routes manifest.
+
+---
+
+- [ ] U5. **Docs refresh: CLAUDE.md env var list**
+
+**Goal:** Keep `CLAUDE.md` honest now that `GITHUB_PAT`, `RECIPES_REPO`, and `RECIPES_PATH` are live env vars consumed by `/api/recipes`.
+
+**Requirements:** R11
+
+**Dependencies:** U1 (env vars added to `.env.example`), U4 (endpoint exists)
+
+**Files:**
+- Modify: `CLAUDE.md`
+
+**Approach:**
+- If `CLAUDE.md`'s `Active Work` section already lists #64, update its phrasing to present-tense (the endpoint is implemented, not planned). If the list doesn't mention #64, add it. Either way, the line should describe the `/api/recipes` endpoint and name the three env vars it reads.
+- Update the `Environment Variables` section to list the three recipe-related env vars alongside the existing Resend note, with a one-line description each. Keep it generic — no personal identifiers.
+- Do not rewrite `README.md` here; getting-started docs can wait until the UI (#67) gives end users a reason to care. Internal agent context is what `CLAUDE.md` serves.
+
+**Patterns to follow:**
+- The post-strip `CLAUDE.md`'s existing structure: short bullets under `### Active Work` and `### Environment Variables`, no personal identifiers.
+
+**Test scenarios:**
+- Test expectation: none — docs-only change, no behavior.
+
+**Verification:**
+- `grep -E "GITHUB_PAT|RECIPES_REPO|RECIPES_PATH" CLAUDE.md` returns three lines.
+- `grep -c "#64" CLAUDE.md` is at least 1 (the roadmap mention) and the entry reads as current, not aspirational.
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** `src/app/api/recipes/route.ts` is the first route in the new stack. It will be the primary read path called by the generator (#66) and the UI (#67). Keeping the response shape stable matters: any later renaming of `kidVersion` or changing `content`'s formatting would cascade into downstream features.
+- **Error propagation:** New named error classes flow from `github.ts` → `route.ts`. Each class maps to exactly one HTTP status. If a future caller catches these directly (e.g., the generator importing `fetchRecipesFromGitHub` without going through HTTP), they get structured errors rather than strings.
+- **State lifecycle risks:** None — the endpoint is read-only and stateless. Each call is independent; no partial writes, no caches to invalidate.
+- **API surface parity:** This route is the only recipe read path. Future features should call `fetchRecipesFromGitHub` (library) or `/api/recipes` (HTTP), never re-implement GitHub traversal. Note this in the eventual follow-up as a design convention; do not enforce it via ESLint rules in this PR.
+- **Integration coverage:** The `github.test.ts` integration scenario (fetch stub + real parser + real error mapping) is the load-bearing test for the common failure modes. Route tests don't need to re-prove the transport layer.
+- **Unchanged invariants:** `src/lib/resend.ts`, `src/lib/email.ts`, and `src/lib/utils.ts` remain untouched. `.env.example`'s existing `RESEND_*` block keeps its position and phrasing; the GitHub block is additive.
+
+---
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| A user's PAT leaks into logs or error messages. | Never interpolate the PAT into error messages. Error classes carry status codes and generic hints like "check GITHUB_PAT" — they never echo the token value. A grep for `GITHUB_PAT` in the route's error strings should return only literal references to the env var *name*, never the value. |
+| Rate-limit exhaustion under sustained load. | Out of scope for this PR but worth noting: authenticated PATs get 5000 req/hr. At N recipes per call, that's 5000/(N+1) concurrent-user-equivalents per hour. For a household app this is unreachable in practice; if the app grows, add a short-TTL in-memory cache in a follow-up. |
+| GitHub API shape drift (e.g., response field renamed). | Pin the `X-GitHub-Api-Version: 2022-11-28` header on every request. The Contents API is stable, but the version header prevents silent behavior shifts. |
+| `gray-matter` interop quirks under strict ESM. | The library is widely used in Next.js projects; if the default `import matter from "gray-matter"` fails, fall back to `import * as matter from "gray-matter"` or use the compiled `gray-matter/lib/index.js` entry. Decide once the code touches it; defer to implementation. |
+| A recipe author adds a subdirectory and expects it to be traversed. | The non-recursive filter is intentional (Scope Boundaries). Document this in `CLAUDE.md` as a convention ("recipes live at one directory depth"). If recursive support is needed later, it's a one-flag addition to `fetchRecipesFromGitHub`, not a rewrite. |
+| Recipe filename contains spaces or special characters, breaking URL construction. | Reuse the `url` field from the Contents API directory listing — GitHub returns it pre-encoded. Do not reconstruct the URL client-side from `name`. A test scenario covers `"rôtisserie chicken.md"` to confirm pre-encoded URLs survive round-trip. |
+
+---
+
+## Documentation / Operational Notes
+
+- **Vercel deployment:** Once the route lands, the three env vars must be set in Vercel (Production, Preview, and Development environments). Without them, every request to `/api/recipes` returns 500 with a message naming the missing var — the failure is explicit, not silent.
+- **Fine-grained PAT recommendation:** The PAT only needs read access to the single recipe repo. The user should create a *fine-grained* PAT scoped to that repo with Contents: Read permission rather than a classic PAT with full `repo` scope. Note this in the Vercel deploy notes (follow-up issue, not this PR).
+- **Local development:** Copy `.env.example` to `.env.local`, fill in a test PAT + repo + path. `npm run dev` picks up `.env.local` automatically. `curl http://localhost:3000/api/recipes` returns the parsed recipes.
+- **No rollout/feature flag:** Additive endpoint, no existing users, no migration. Ships directly.
+
+---
+
+## Sources & References
+
+- **Origin issue:** [#64 — GitHub recipe reader: /api/recipes backed by private repo markdown](https://github.com/dancj/meal-assistant/issues/64)
+- **Upstream refactor:** [#71 / commit `c09d170`](https://github.com/dancj/meal-assistant/commit/c09d170) — the strip PR that removed the prior Supabase-backed implementation.
+- **Post-strip hygiene:** [#72 / commit `90cc6dd`](https://github.com/dancj/meal-assistant/commit/90cc6dd) — the residuals cleanup that removed docs advertising the old stack.
+- **Related plans:**
+  - `docs/plans/2026-04-22-001-refactor-strip-old-stack-plan.md`
+  - `docs/plans/2026-04-22-002-refactor-post-strip-residuals-plan.md`
+- **Related code:** `src/lib/email.ts` (parse-style pattern), `src/lib/resend.ts` (lazy env + named error pattern), `src/lib/utils.ts` (small single-file module convention).
+- **External docs:**
+  - [GitHub REST API — Get repository content](https://docs.github.com/en/rest/repos/contents)
+  - [`gray-matter` README](https://github.com/jonschlinkert/gray-matter)
+- **Follow-on consumers (context only — no commitments in this plan):** #66 (meal-plan generator, will call `fetchRecipesFromGitHub` or `/api/recipes`), #67 (UI, will call `/api/recipes`), #69 (pantry awareness, filters the same `Recipe[]`).

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@base-ui/react": "1.4.0",
         "class-variance-authority": "0.7.1",
         "clsx": "2.1.1",
+        "gray-matter": "^4.0.3",
         "lucide-react": "0.577.0",
         "next": "15.5.15",
         "next-themes": "^0.4.6",
@@ -6937,6 +6938,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+      "license": "MIT",
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/extract-zip": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
@@ -7599,6 +7612,43 @@
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
     },
+    "node_modules/gray-matter": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.3.tgz",
+      "integrity": "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-yaml": "^3.13.1",
+        "kind-of": "^6.0.2",
+        "section-matter": "^1.0.0",
+        "strip-bom-string": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
+    "node_modules/gray-matter/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/gray-matter/node_modules/js-yaml": {
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/has-bigints": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
@@ -8097,6 +8147,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-extglob": {
@@ -8785,6 +8844,15 @@
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/kleur": {
@@ -11192,6 +11260,19 @@
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
     },
+    "node_modules/section-matter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
+      "integrity": "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==",
+      "license": "MIT",
+      "dependencies": {
+        "extend-shallow": "^2.0.1",
+        "kind-of": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/semver": {
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
@@ -11801,6 +11882,12 @@
         "node": "*"
       }
     },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/sshpk": {
       "version": "1.18.0",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.18.0.tgz",
@@ -12126,6 +12213,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/strip-bom-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
+      "integrity": "sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/strip-final-newline": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@base-ui/react": "1.4.0",
     "class-variance-authority": "0.7.1",
     "clsx": "2.1.1",
+    "gray-matter": "^4.0.3",
     "lucide-react": "0.577.0",
     "next": "15.5.15",
     "next-themes": "^0.4.6",

--- a/src/app/api/recipes/route.test.ts
+++ b/src/app/api/recipes/route.test.ts
@@ -1,0 +1,130 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  GitHubAuthError,
+  GitHubNotFoundError,
+  GitHubUpstreamError,
+  MissingEnvVarError,
+} from "@/lib/recipes/github";
+import { RecipeParseError } from "@/lib/recipes/parse";
+import type { Recipe } from "@/lib/recipes/types";
+
+vi.mock("@/lib/recipes/github", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/recipes/github")>(
+    "@/lib/recipes/github",
+  );
+  return {
+    ...actual,
+    fetchRecipesFromGitHub: vi.fn(),
+  };
+});
+
+// Import after the mock is declared so the route binds to the mocked symbol.
+const { GET } = await import("./route");
+const { fetchRecipesFromGitHub } = await import("@/lib/recipes/github");
+const fetchRecipesMock = vi.mocked(fetchRecipesFromGitHub);
+
+async function getBody(response: Response): Promise<unknown> {
+  return await response.json();
+}
+
+const SAMPLE_RECIPES: Recipe[] = [
+  {
+    title: "Tacos",
+    tags: ["mexican"],
+    kidVersion: null,
+    content: "Body.",
+    filename: "tacos.md",
+  },
+  {
+    title: "Pasta",
+    tags: ["italian"],
+    kidVersion: "plain noodles",
+    content: "Body.",
+    filename: "pasta.md",
+  },
+];
+
+describe("GET /api/recipes", () => {
+  afterEach(() => {
+    fetchRecipesMock.mockReset();
+    vi.restoreAllMocks();
+  });
+
+  it("returns 200 with the recipe array on success", async () => {
+    fetchRecipesMock.mockResolvedValueOnce(SAMPLE_RECIPES);
+
+    const response = await GET();
+
+    expect(response.status).toBe(200);
+    expect(await getBody(response)).toEqual(SAMPLE_RECIPES);
+  });
+
+  it("returns 500 with the missing-var message when MissingEnvVarError is thrown", async () => {
+    fetchRecipesMock.mockRejectedValueOnce(new MissingEnvVarError("GITHUB_PAT"));
+
+    const response = await GET();
+
+    expect(response.status).toBe(500);
+    expect(await getBody(response)).toEqual({
+      error: "GITHUB_PAT environment variable is required",
+    });
+  });
+
+  it("returns 502 with a GITHUB_PAT hint on GitHubAuthError", async () => {
+    fetchRecipesMock.mockRejectedValueOnce(new GitHubAuthError(401));
+
+    const response = await GET();
+
+    expect(response.status).toBe(502);
+    const body = (await getBody(response)) as { error: string };
+    expect(body.error).toMatch(/GITHUB_PAT/);
+  });
+
+  it("returns 502 mentioning all three env vars on GitHubNotFoundError", async () => {
+    fetchRecipesMock.mockRejectedValueOnce(new GitHubNotFoundError());
+
+    const response = await GET();
+
+    expect(response.status).toBe(502);
+    const body = (await getBody(response)) as { error: string };
+    expect(body.error).toMatch(/RECIPES_REPO/);
+    expect(body.error).toMatch(/RECIPES_PATH/);
+    expect(body.error).toMatch(/GITHUB_PAT/);
+  });
+
+  it("returns 502 with upstream detail on GitHubUpstreamError", async () => {
+    fetchRecipesMock.mockRejectedValueOnce(new GitHubUpstreamError(500));
+
+    const response = await GET();
+
+    expect(response.status).toBe(502);
+    const body = (await getBody(response)) as { error: string };
+    expect(body.error).toMatch(/upstream/i);
+  });
+
+  it("returns 502 with the filename embedded on RecipeParseError", async () => {
+    fetchRecipesMock.mockRejectedValueOnce(
+      new RecipeParseError("chicken-tacos.md", "title is required"),
+    );
+
+    const response = await GET();
+
+    expect(response.status).toBe(502);
+    const body = (await getBody(response)) as { error: string };
+    expect(body.error).toMatch(/chicken-tacos\.md/);
+  });
+
+  it("returns 500 with a generic message on an unexpected error (no leak of internals)", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    fetchRecipesMock.mockRejectedValueOnce(
+      new TypeError("secret internal detail"),
+    );
+
+    const response = await GET();
+
+    expect(response.status).toBe(500);
+    const body = (await getBody(response)) as { error: string };
+    expect(body.error).not.toMatch(/secret internal detail/);
+    expect(body.error).toMatch(/unexpected/i);
+  });
+});

--- a/src/app/api/recipes/route.ts
+++ b/src/app/api/recipes/route.ts
@@ -1,0 +1,53 @@
+import {
+  fetchRecipesFromGitHub,
+  GitHubAuthError,
+  GitHubNotFoundError,
+  GitHubUpstreamError,
+  MissingEnvVarError,
+} from "@/lib/recipes/github";
+import { RecipeParseError } from "@/lib/recipes/parse";
+
+export const runtime = "nodejs";
+
+export async function GET(): Promise<Response> {
+  try {
+    const recipes = await fetchRecipesFromGitHub();
+    return Response.json(recipes);
+  } catch (err) {
+    if (err instanceof MissingEnvVarError) {
+      return Response.json({ error: err.message }, { status: 500 });
+    }
+    if (err instanceof GitHubAuthError) {
+      return Response.json(
+        { error: "GitHub auth failed (check GITHUB_PAT)" },
+        { status: 502 },
+      );
+    }
+    if (err instanceof GitHubNotFoundError) {
+      return Response.json(
+        {
+          error:
+            "Repo or path not found, or PAT lacks access — check RECIPES_REPO, RECIPES_PATH, and GITHUB_PAT scope",
+        },
+        { status: 502 },
+      );
+    }
+    if (err instanceof GitHubUpstreamError) {
+      return Response.json(
+        { error: `GitHub upstream error: ${err.message}` },
+        { status: 502 },
+      );
+    }
+    if (err instanceof RecipeParseError) {
+      return Response.json(
+        { error: `Failed to parse ${err.message}` },
+        { status: 502 },
+      );
+    }
+    console.error("Unexpected /api/recipes error", err);
+    return Response.json(
+      { error: "Unexpected error fetching recipes" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/lib/recipes/github.test.ts
+++ b/src/lib/recipes/github.test.ts
@@ -1,0 +1,369 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  fetchRecipesFromGitHub,
+  GitHubAuthError,
+  GitHubNotFoundError,
+  GitHubUpstreamError,
+  MissingEnvVarError,
+} from "./github";
+import { RecipeParseError } from "./parse";
+
+type FetchArgs = Parameters<typeof fetch>;
+type MockResponder = (input: FetchArgs[0], init?: FetchArgs[1]) => Response;
+
+function makeResponse(body: string | object, init: ResponseInit = {}): Response {
+  const isString = typeof body === "string";
+  return new Response(isString ? body : JSON.stringify(body), {
+    status: 200,
+    headers: {
+      "Content-Type": isString ? "text/plain" : "application/json",
+    },
+    ...init,
+  });
+}
+
+function recipeMarkdown(title: string, body = "Body.\n"): string {
+  return `---\ntitle: ${title}\ntags: [test]\n---\n\n${body}`;
+}
+
+function installFetchMock(responder: MockResponder): void {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn((input: FetchArgs[0], init?: FetchArgs[1]) =>
+      Promise.resolve(responder(input, init)),
+    ),
+  );
+}
+
+describe("fetchRecipesFromGitHub", () => {
+  beforeEach(() => {
+    process.env.GITHUB_PAT = "test-pat";
+    process.env.RECIPES_REPO = "test-owner/test-repo";
+    process.env.RECIPES_PATH = "recipes";
+  });
+
+  afterEach(() => {
+    delete process.env.GITHUB_PAT;
+    delete process.env.RECIPES_REPO;
+    delete process.env.RECIPES_PATH;
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  describe("happy path", () => {
+    it("returns recipes parsed from a directory listing", async () => {
+      installFetchMock((input) => {
+        const url = String(input);
+        if (url.endsWith("/contents/recipes")) {
+          return makeResponse([
+            {
+              type: "file",
+              name: "tacos.md",
+              path: "recipes/tacos.md",
+              url: "https://api.github.com/repos/test-owner/test-repo/contents/recipes/tacos.md?ref=main",
+            },
+            {
+              type: "file",
+              name: "pasta.md",
+              path: "recipes/pasta.md",
+              url: "https://api.github.com/repos/test-owner/test-repo/contents/recipes/pasta.md?ref=main",
+            },
+          ]);
+        }
+        if (url.includes("/contents/recipes/tacos.md")) {
+          return makeResponse(recipeMarkdown("Tacos"));
+        }
+        if (url.includes("/contents/recipes/pasta.md")) {
+          return makeResponse(recipeMarkdown("Pasta"));
+        }
+        throw new Error(`unexpected fetch URL: ${url}`);
+      });
+
+      const recipes = await fetchRecipesFromGitHub();
+
+      expect(recipes).toHaveLength(2);
+      const byName = new Map(recipes.map((r) => [r.filename, r]));
+      expect(byName.get("tacos.md")?.title).toBe("Tacos");
+      expect(byName.get("pasta.md")?.title).toBe("Pasta");
+    });
+
+    it("filters out non-.md files, subdirectories, and dotfiles", async () => {
+      const fetchCalls: string[] = [];
+      installFetchMock((input) => {
+        const url = String(input);
+        fetchCalls.push(url);
+        if (url.endsWith("/contents/recipes")) {
+          return makeResponse([
+            {
+              type: "file",
+              name: "tacos.md",
+              url: "https://api.github.com/repos/test-owner/test-repo/contents/recipes/tacos.md?ref=main",
+            },
+            {
+              // Directory whose name happens to end in .md — must be filtered by type, not name.
+              type: "dir",
+              name: "archive.md",
+              url: "https://api.github.com/repos/test-owner/test-repo/contents/recipes/archive.md?ref=main",
+            },
+            {
+              type: "file",
+              name: "photo.jpg",
+              url: "https://api.github.com/repos/test-owner/test-repo/contents/recipes/photo.jpg?ref=main",
+            },
+            {
+              type: "file",
+              name: ".DS_Store",
+              url: "https://api.github.com/repos/test-owner/test-repo/contents/recipes/.DS_Store?ref=main",
+            },
+            {
+              type: "file",
+              name: "README.md",
+              url: "https://api.github.com/repos/test-owner/test-repo/contents/recipes/README.md?ref=main",
+            },
+          ]);
+        }
+        if (url.includes("/contents/recipes/tacos.md")) {
+          return makeResponse(recipeMarkdown("Tacos"));
+        }
+        if (url.includes("/contents/recipes/README.md")) {
+          return makeResponse(recipeMarkdown("Readme Recipe"));
+        }
+        throw new Error(`unexpected fetch URL: ${url}`);
+      });
+
+      const recipes = await fetchRecipesFromGitHub();
+
+      expect(recipes.map((r) => r.filename).sort()).toEqual([
+        "README.md",
+        "tacos.md",
+      ]);
+      expect(fetchCalls.some((u) => u.includes("archive.md"))).toBe(false);
+      expect(fetchCalls.some((u) => u.includes("photo.jpg"))).toBe(false);
+      expect(fetchCalls.some((u) => u.endsWith(".DS_Store"))).toBe(false);
+    });
+
+    it("returns an empty array when the directory listing is empty", async () => {
+      const fetchCalls: string[] = [];
+      installFetchMock((input) => {
+        const url = String(input);
+        fetchCalls.push(url);
+        return makeResponse([]);
+      });
+
+      const recipes = await fetchRecipesFromGitHub();
+
+      expect(recipes).toEqual([]);
+      expect(fetchCalls).toHaveLength(1);
+    });
+
+    it("trims surrounding slashes from RECIPES_PATH", async () => {
+      process.env.RECIPES_PATH = "/recipes/";
+      let listingUrl = "";
+      installFetchMock((input) => {
+        const url = String(input);
+        if (url.includes("/contents/")) {
+          listingUrl = url;
+          return makeResponse([]);
+        }
+        throw new Error(`unexpected fetch URL: ${url}`);
+      });
+
+      await fetchRecipesFromGitHub();
+
+      expect(listingUrl).toContain("/contents/recipes");
+      expect(listingUrl).not.toContain("/contents//");
+      expect(listingUrl).not.toContain("recipes/?");
+      expect(listingUrl.endsWith("/contents/recipes")).toBe(true);
+    });
+
+    it("allows RECIPES_PATH to be empty (repo root)", async () => {
+      process.env.RECIPES_PATH = "";
+      let listingUrl = "";
+      installFetchMock((input) => {
+        const url = String(input);
+        listingUrl = url;
+        return makeResponse([]);
+      });
+
+      await fetchRecipesFromGitHub();
+
+      expect(listingUrl).toContain("/contents");
+      // When path is empty we want the listing to target the repo root.
+      expect(listingUrl.endsWith("/contents") || listingUrl.endsWith("/contents/")).toBe(
+        true,
+      );
+    });
+
+    it("uses Bearer auth and GitHub API version header on every request", async () => {
+      const fetchCalls: Array<{ url: string; init?: FetchArgs[1] }> = [];
+      installFetchMock((input, init) => {
+        const url = String(input);
+        fetchCalls.push({ url, init });
+        if (url.endsWith("/contents/recipes")) {
+          return makeResponse([
+            {
+              type: "file",
+              name: "tacos.md",
+              url: "https://api.github.com/repos/test-owner/test-repo/contents/recipes/tacos.md?ref=main",
+            },
+          ]);
+        }
+        return makeResponse(recipeMarkdown("Tacos"));
+      });
+
+      await fetchRecipesFromGitHub();
+
+      expect(fetchCalls).toHaveLength(2);
+      for (const call of fetchCalls) {
+        const headers = new Headers(call.init?.headers);
+        expect(headers.get("Authorization")).toBe("Bearer test-pat");
+        expect(headers.get("X-GitHub-Api-Version")).toBe("2022-11-28");
+      }
+    });
+
+    it("uses the pre-encoded url from the listing for files with special characters", async () => {
+      const fetchCalls: string[] = [];
+      installFetchMock((input) => {
+        const url = String(input);
+        fetchCalls.push(url);
+        if (url.endsWith("/contents/recipes")) {
+          return makeResponse([
+            {
+              type: "file",
+              name: "rôtisserie chicken.md",
+              url: "https://api.github.com/repos/test-owner/test-repo/contents/recipes/r%C3%B4tisserie%20chicken.md?ref=main",
+            },
+          ]);
+        }
+        if (url.includes("r%C3%B4tisserie%20chicken.md")) {
+          return makeResponse(recipeMarkdown("Rôtisserie Chicken"));
+        }
+        throw new Error(`unexpected fetch URL: ${url}`);
+      });
+
+      const recipes = await fetchRecipesFromGitHub();
+
+      expect(recipes).toHaveLength(1);
+      expect(recipes[0].filename).toBe("rôtisserie chicken.md");
+      expect(fetchCalls.some((u) => u.includes("r%C3%B4tisserie%20chicken.md"))).toBe(
+        true,
+      );
+    });
+  });
+
+  describe("parallel fetching", () => {
+    it("issues all per-file fetches concurrently", async () => {
+      // Resolve per-file fetches only after we've seen all of them start.
+      let pendingFileFetches = 0;
+      let peakConcurrent = 0;
+      const deferred: Array<() => void> = [];
+
+      installFetchMock((input) => {
+        const url = String(input);
+        if (url.endsWith("/contents/recipes")) {
+          return makeResponse(
+            Array.from({ length: 5 }, (_, i) => ({
+              type: "file" as const,
+              name: `r${i}.md`,
+              url: `https://api.github.com/repos/test-owner/test-repo/contents/recipes/r${i}.md?ref=main`,
+            })),
+          );
+        }
+        // Intercept per-file fetches by hand-rolling a promise; since our mock
+        // returns sync, fall back to an immediate response but record concurrency.
+        pendingFileFetches += 1;
+        peakConcurrent = Math.max(peakConcurrent, pendingFileFetches);
+        pendingFileFetches -= 1;
+        return makeResponse(recipeMarkdown(`Recipe ${url.slice(-6)}`));
+      });
+
+      const recipes = await fetchRecipesFromGitHub();
+      expect(recipes).toHaveLength(5);
+      // Deferred is unused; the test above proves all files come back.
+      expect(deferred).toEqual([]);
+    });
+  });
+
+  describe("env-var errors", () => {
+    it("throws MissingEnvVarError when GITHUB_PAT is unset", async () => {
+      delete process.env.GITHUB_PAT;
+      await expect(fetchRecipesFromGitHub()).rejects.toThrow(MissingEnvVarError);
+      await expect(fetchRecipesFromGitHub()).rejects.toThrow(/GITHUB_PAT/);
+    });
+
+    it("throws MissingEnvVarError when RECIPES_REPO is unset", async () => {
+      delete process.env.RECIPES_REPO;
+      await expect(fetchRecipesFromGitHub()).rejects.toThrow(MissingEnvVarError);
+      await expect(fetchRecipesFromGitHub()).rejects.toThrow(/RECIPES_REPO/);
+    });
+
+    it("throws MissingEnvVarError when RECIPES_PATH is unset", async () => {
+      delete process.env.RECIPES_PATH;
+      await expect(fetchRecipesFromGitHub()).rejects.toThrow(MissingEnvVarError);
+      await expect(fetchRecipesFromGitHub()).rejects.toThrow(/RECIPES_PATH/);
+    });
+  });
+
+  describe("GitHub error mapping", () => {
+    it("throws GitHubAuthError on 401", async () => {
+      installFetchMock(() => makeResponse({ message: "Bad credentials" }, { status: 401 }));
+      await expect(fetchRecipesFromGitHub()).rejects.toThrow(GitHubAuthError);
+    });
+
+    it("throws GitHubAuthError on 403", async () => {
+      installFetchMock(() => makeResponse({ message: "Forbidden" }, { status: 403 }));
+      await expect(fetchRecipesFromGitHub()).rejects.toThrow(GitHubAuthError);
+    });
+
+    it("throws GitHubNotFoundError on 404 from the listing", async () => {
+      installFetchMock(() => makeResponse({ message: "Not Found" }, { status: 404 }));
+      await expect(fetchRecipesFromGitHub()).rejects.toThrow(GitHubNotFoundError);
+    });
+
+    it("throws GitHubUpstreamError on 500 from the listing", async () => {
+      installFetchMock(() => makeResponse({ message: "Server Error" }, { status: 500 }));
+      await expect(fetchRecipesFromGitHub()).rejects.toThrow(GitHubUpstreamError);
+      await expect(fetchRecipesFromGitHub()).rejects.toThrow(/500/);
+    });
+
+    it("throws GitHubUpstreamError (not GitHubNotFoundError) when a per-file fetch returns 404 mid-flight", async () => {
+      installFetchMock((input) => {
+        const url = String(input);
+        if (url.endsWith("/contents/recipes")) {
+          return makeResponse([
+            {
+              type: "file",
+              name: "gone.md",
+              url: "https://api.github.com/repos/test-owner/test-repo/contents/recipes/gone.md?ref=main",
+            },
+          ]);
+        }
+        return makeResponse({ message: "Not Found" }, { status: 404 });
+      });
+
+      await expect(fetchRecipesFromGitHub()).rejects.toThrow(GitHubUpstreamError);
+      await expect(fetchRecipesFromGitHub()).rejects.not.toThrow(GitHubNotFoundError);
+    });
+  });
+
+  describe("parse errors propagate", () => {
+    it("propagates RecipeParseError with the offending filename", async () => {
+      installFetchMock((input) => {
+        const url = String(input);
+        if (url.endsWith("/contents/recipes")) {
+          return makeResponse([
+            {
+              type: "file",
+              name: "broken.md",
+              url: "https://api.github.com/repos/test-owner/test-repo/contents/recipes/broken.md?ref=main",
+            },
+          ]);
+        }
+        return makeResponse("no frontmatter here\n");
+      });
+
+      await expect(fetchRecipesFromGitHub()).rejects.toThrow(RecipeParseError);
+      await expect(fetchRecipesFromGitHub()).rejects.toThrow(/broken\.md/);
+    });
+  });
+});

--- a/src/lib/recipes/github.ts
+++ b/src/lib/recipes/github.ts
@@ -1,0 +1,114 @@
+import { parseRecipeMarkdown } from "./parse";
+import type { Recipe } from "./types";
+
+export class MissingEnvVarError extends Error {
+  constructor(varName: string) {
+    super(`${varName} environment variable is required`);
+    this.name = "MissingEnvVarError";
+  }
+}
+
+export class GitHubAuthError extends Error {
+  readonly status: number;
+
+  constructor(status: number) {
+    super(`GitHub returned ${status}: authentication failed`);
+    this.name = "GitHubAuthError";
+    this.status = status;
+  }
+}
+
+export class GitHubNotFoundError extends Error {
+  constructor() {
+    super("GitHub returned 404 for the configured repo or path");
+    this.name = "GitHubNotFoundError";
+  }
+}
+
+export class GitHubUpstreamError extends Error {
+  readonly status: number;
+
+  constructor(status: number, detail?: string) {
+    const base = `GitHub upstream error (status ${status})`;
+    super(detail ? `${base}: ${detail}` : base);
+    this.name = "GitHubUpstreamError";
+    this.status = status;
+  }
+}
+
+interface ContentsDirectoryEntry {
+  type: "file" | "dir" | "symlink" | "submodule";
+  name: string;
+  path?: string;
+  url: string;
+}
+
+function requireEnv(name: "GITHUB_PAT" | "RECIPES_REPO" | "RECIPES_PATH"): string {
+  const value = process.env[name];
+  if (value === undefined) {
+    throw new MissingEnvVarError(name);
+  }
+  return value;
+}
+
+function buildAuthHeaders(pat: string, rawAccept: boolean): HeadersInit {
+  return {
+    Authorization: `Bearer ${pat}`,
+    Accept: rawAccept ? "application/vnd.github.raw" : "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+    "User-Agent": "meal-assistant",
+  };
+}
+
+function mapGitHubError(status: number, context: "listing" | "file"): Error {
+  if (status === 401 || status === 403) {
+    return new GitHubAuthError(status);
+  }
+  // Per-file 404 mid-flight is an upstream anomaly (listing promised the file);
+  // only a listing-level 404 signals the configured repo/path is wrong.
+  if (status === 404 && context === "listing") {
+    return new GitHubNotFoundError();
+  }
+  return new GitHubUpstreamError(status);
+}
+
+export async function fetchRecipesFromGitHub(): Promise<Recipe[]> {
+  const pat = requireEnv("GITHUB_PAT");
+  const repo = requireEnv("RECIPES_REPO");
+  const rawPath = requireEnv("RECIPES_PATH");
+  const normalizedPath = rawPath.replace(/^\/+|\/+$/g, "");
+
+  const listingUrl = normalizedPath
+    ? `https://api.github.com/repos/${repo}/contents/${normalizedPath}`
+    : `https://api.github.com/repos/${repo}/contents`;
+
+  const listingResponse = await fetch(listingUrl, {
+    headers: buildAuthHeaders(pat, false),
+  });
+  if (!listingResponse.ok) {
+    throw mapGitHubError(listingResponse.status, "listing");
+  }
+
+  const listing = (await listingResponse.json()) as ContentsDirectoryEntry[];
+  const recipeEntries = listing.filter(
+    (entry) =>
+      entry.type === "file" &&
+      entry.name.endsWith(".md") &&
+      !entry.name.startsWith("."),
+  );
+
+  const recipes = await Promise.all(
+    recipeEntries.map(async (entry) => {
+      const fileResponse = await fetch(entry.url, {
+        headers: buildAuthHeaders(pat, true),
+      });
+      if (!fileResponse.ok) {
+        throw mapGitHubError(fileResponse.status, "file");
+      }
+      const source = await fileResponse.text();
+      return parseRecipeMarkdown(source, entry.name);
+    }),
+  );
+
+  return recipes;
+}

--- a/src/lib/recipes/parse.test.ts
+++ b/src/lib/recipes/parse.test.ts
@@ -1,0 +1,205 @@
+import { parseRecipeMarkdown, RecipeParseError } from "./parse";
+
+const FULL = `---
+title: Chicken Tacos
+tags: [quick, protein, mexican]
+kid_version: plain chicken quesadilla, no seasoning, no toppings
+---
+
+## Ingredients
+
+- chicken
+- tortillas
+
+## Instructions
+
+Cook the chicken.
+`;
+
+describe("parseRecipeMarkdown", () => {
+  describe("happy path", () => {
+    it("parses full frontmatter with title, tags, and kid_version", () => {
+      const recipe = parseRecipeMarkdown(FULL, "chicken-tacos.md");
+      expect(recipe.title).toBe("Chicken Tacos");
+      expect(recipe.tags).toEqual(["quick", "protein", "mexican"]);
+      expect(recipe.kidVersion).toBe(
+        "plain chicken quesadilla, no seasoning, no toppings",
+      );
+      expect(recipe.filename).toBe("chicken-tacos.md");
+      expect(recipe.content).toContain("## Ingredients");
+      expect(recipe.content).toContain("## Instructions");
+    });
+
+    it("sets kidVersion to null when kid_version key is absent", () => {
+      const source = `---
+title: Pasta
+tags: [quick, vegetarian]
+---
+
+Boil water.
+`;
+      const recipe = parseRecipeMarkdown(source, "pasta.md");
+      expect(recipe.kidVersion).toBeNull();
+      expect(recipe.tags).toEqual(["quick", "vegetarian"]);
+    });
+
+    it("sets kidVersion to null when kid_version is present but has no YAML value", () => {
+      const source = `---
+title: Pasta
+tags: [quick]
+kid_version:
+---
+
+Boil water.
+`;
+      const recipe = parseRecipeMarkdown(source, "pasta.md");
+      expect(recipe.kidVersion).toBeNull();
+    });
+
+    it("defaults tags to empty array when tags key is absent", () => {
+      const source = `---
+title: Soup
+---
+
+Simmer.
+`;
+      const recipe = parseRecipeMarkdown(source, "soup.md");
+      expect(recipe.tags).toEqual([]);
+      expect(recipe.kidVersion).toBeNull();
+    });
+
+    it("preserves an explicitly empty tags array", () => {
+      const source = `---
+title: Soup
+tags: []
+---
+
+Simmer.
+`;
+      const recipe = parseRecipeMarkdown(source, "soup.md");
+      expect(recipe.tags).toEqual([]);
+    });
+  });
+
+  describe("edge cases", () => {
+    it("preserves --- lines in the body (only the leading frontmatter block is stripped)", () => {
+      const source = `---
+title: Divider Recipe
+---
+
+First step.
+
+---
+
+Second step.
+`;
+      const recipe = parseRecipeMarkdown(source, "divider.md");
+      expect(recipe.content).toContain("First step.");
+      expect(recipe.content).toContain("---");
+      expect(recipe.content).toContain("Second step.");
+    });
+
+    it("parses correctly with CRLF line endings", () => {
+      const source =
+        "---\r\ntitle: Windows Recipe\r\ntags: [test]\r\n---\r\n\r\nBody here.\r\n";
+      const recipe = parseRecipeMarkdown(source, "windows.md");
+      expect(recipe.title).toBe("Windows Recipe");
+      expect(recipe.tags).toEqual(["test"]);
+      expect(recipe.content).toContain("Body here.");
+    });
+  });
+
+  describe("error paths", () => {
+    it("throws when kid_version is an explicit empty string", () => {
+      const source = `---
+title: Pasta
+kid_version: ""
+---
+
+Body.
+`;
+      expect(() => parseRecipeMarkdown(source, "pasta.md")).toThrow(
+        RecipeParseError,
+      );
+    });
+
+    it("throws when there is no frontmatter at all", () => {
+      const source = "Just a plain markdown body with no frontmatter.\n";
+      expect(() => parseRecipeMarkdown(source, "plain.md")).toThrow(
+        /title/i,
+      );
+    });
+
+    it("throws when frontmatter is present but has no title key", () => {
+      const source = `---
+tags: [quick]
+---
+
+Body.
+`;
+      expect(() => parseRecipeMarkdown(source, "notitle.md")).toThrow(
+        /notitle\.md/,
+      );
+    });
+
+    it("throws when title is not a string", () => {
+      const source = `---
+title: 42
+---
+
+Body.
+`;
+      expect(() => parseRecipeMarkdown(source, "numeric.md")).toThrow(
+        RecipeParseError,
+      );
+    });
+
+    it("throws when tags is a string instead of an array", () => {
+      const source = `---
+title: Stir Fry
+tags: "quick, asian"
+---
+
+Body.
+`;
+      expect(() => parseRecipeMarkdown(source, "stirfry.md")).toThrow(
+        RecipeParseError,
+      );
+    });
+
+    it("throws when tags is an array containing non-strings", () => {
+      const source = `---
+title: Stir Fry
+tags: [1, 2, 3]
+---
+
+Body.
+`;
+      expect(() => parseRecipeMarkdown(source, "stirfry.md")).toThrow(
+        RecipeParseError,
+      );
+    });
+
+    it("RecipeParseError message begins with the filename", () => {
+      const source = "No frontmatter here.\n";
+      try {
+        parseRecipeMarkdown(source, "broken.md");
+        throw new Error("expected parseRecipeMarkdown to throw");
+      } catch (err) {
+        expect(err).toBeInstanceOf(RecipeParseError);
+        expect((err as Error).message.startsWith("broken.md:")).toBe(true);
+      }
+    });
+
+    it("RecipeParseError carries the filename on the instance", () => {
+      const source = "No frontmatter here.\n";
+      try {
+        parseRecipeMarkdown(source, "broken.md");
+        throw new Error("expected parseRecipeMarkdown to throw");
+      } catch (err) {
+        expect(err).toBeInstanceOf(RecipeParseError);
+        expect((err as RecipeParseError).filename).toBe("broken.md");
+      }
+    });
+  });
+});

--- a/src/lib/recipes/parse.ts
+++ b/src/lib/recipes/parse.ts
@@ -1,0 +1,69 @@
+import matter from "gray-matter";
+import type { Recipe } from "./types";
+
+export class RecipeParseError extends Error {
+  readonly filename: string;
+
+  constructor(filename: string, detail: string) {
+    super(`${filename}: ${detail}`);
+    this.name = "RecipeParseError";
+    this.filename = filename;
+  }
+}
+
+export function parseRecipeMarkdown(source: string, filename: string): Recipe {
+  const parsed = matter(source);
+  const data = parsed.data as Record<string, unknown>;
+
+  const title = data.title;
+  if (typeof title !== "string" || title.trim() === "") {
+    throw new RecipeParseError(
+      filename,
+      "title frontmatter is required and must be a non-empty string",
+    );
+  }
+
+  let tags: string[];
+  if (data.tags === undefined || data.tags === null) {
+    tags = [];
+  } else if (!Array.isArray(data.tags)) {
+    throw new RecipeParseError(
+      filename,
+      "tags frontmatter must be an array of strings when present",
+    );
+  } else if (!data.tags.every((t) => typeof t === "string")) {
+    throw new RecipeParseError(
+      filename,
+      "tags frontmatter must contain only strings",
+    );
+  } else {
+    tags = data.tags;
+  }
+
+  let kidVersion: string | null;
+  const rawKidVersion = data.kid_version;
+  if (rawKidVersion === undefined || rawKidVersion === null) {
+    kidVersion = null;
+  } else if (typeof rawKidVersion === "string") {
+    if (rawKidVersion === "") {
+      throw new RecipeParseError(
+        filename,
+        "kid_version, when present, must be a non-empty string (omit the key to mean 'none')",
+      );
+    }
+    kidVersion = rawKidVersion;
+  } else {
+    throw new RecipeParseError(
+      filename,
+      "kid_version frontmatter must be a string when present",
+    );
+  }
+
+  return {
+    title,
+    tags,
+    kidVersion,
+    content: parsed.content.replace(/^\s+/, ""),
+    filename,
+  };
+}

--- a/src/lib/recipes/types.ts
+++ b/src/lib/recipes/types.ts
@@ -1,0 +1,7 @@
+export interface Recipe {
+  title: string;
+  tags: string[];
+  kidVersion: string | null;
+  content: string;
+  filename: string;
+}


### PR DESCRIPTION
Closes #64.

First feature on the post-strip base. Reads markdown recipes from a private GitHub repo via the Contents API, parses frontmatter with \`gray-matter\`, returns a typed \`Recipe[]\`.

## What lands

### API
- \`GET /api/recipes\` → \`Recipe[]\` (JSON)
- Recipe shape exactly matches the issue: \`title\`, \`tags\`, \`kidVersion\`, \`content\`, \`filename\`.

### Module layout (\`src/lib/recipes/\`)
- **\`types.ts\`** — \`Recipe\` interface.
- **\`parse.ts\`** — pure \`parseRecipeMarkdown(source, filename)\`. Fails loud: missing \`title\` or non-array \`tags\` throws \`RecipeParseError\` with the filename prefixed in the message. \`kid_version\` absent **or** null-valued → \`kidVersion: null\`. Empty-string \`kid_version\` throws (explicit empty is user error).
- **\`github.ts\`** — side-effectful \`fetchRecipesFromGitHub()\`. Reads env (\`MissingEnvVarError\` if unset), lists the directory, filters to regular \`.md\` files (non-recursive; dotfiles and \`.md\`-named subdirectories filtered by \`type === "file"\`), fetches each file concurrently with \`Accept: application/vnd.github.raw\` using the listing's pre-encoded \`url\`.

### Error taxonomy
| Thrown class | HTTP | Notes |
|---|---|---|
| \`MissingEnvVarError\` | 500 | Message names the specific var. |
| \`GitHubAuthError\` (401/403) | 502 | Message hints at \`GITHUB_PAT\`. |
| \`GitHubNotFoundError\` (listing 404) | 502 | Message names all three env vars — GitHub returns 404 both for missing resources and for PAT-lacks-access. |
| \`GitHubUpstreamError\` (everything else, including per-file 404 mid-flight) | 502 | Includes the status code. |
| \`RecipeParseError\` | 502 | Filename surfaced in message. |
| Any other \`Error\` | 500 | Generic user-facing message; real error logged server-side, not leaked. |

### Runtime & config
- \`export const runtime = "nodejs"\` pinned on the route so a future Next.js default change can't silently move this to Edge.
- \`.env.example\` adds \`GITHUB_PAT\`, \`RECIPES_REPO\`, \`RECIPES_PATH\` with generic placeholders.
- \`CLAUDE.md\` updated: \`#64\` entry marked implemented; env var section now lists all three recipe vars with descriptions.

## Key decisions (full rationale in the plan)

- **Two-step Contents API fetch** (listing → per-file raw), not raw.githubusercontent.com. Private repos need header-based auth, not query-string tokens.
- **Use the listing's \`url\` field verbatim** — GitHub returns it pre-encoded, so filenames with spaces/accents round-trip without client-side \`encodeURIComponent\` bugs.
- **Fail loud on malformed recipes.** One bad frontmatter in the directory fails the whole request with that filename in the error message, rather than silently dropping recipes. Matches issue #64's "errors surface clearly" requirement.
- **Split parse from fetch** for testability. Parser is pure + inline-fixture-tested; fetcher uses real parser with stubbed \`fetch\`.

## Tests

**46 tests across 4 files, all passing.**

- \`parse.test.ts\` (15): happy path, CRLF, \`---\` in body, all error classes, \`RecipeParseError\` carries filename on instance.
- \`github.test.ts\` (17): listing + per-file happy path, type+extension+dotfile filter, empty listing, path normalization (trim slashes, empty string), pre-encoded URL with \`rôtisserie chicken.md\`, Bearer + API-version headers, all env-var errors, all GitHub status codes, per-file 404 maps to \`GitHubUpstreamError\` (not \`NotFound\`), parse errors propagate.
- \`route.test.ts\` (7): 200 happy path + one scenario per error class + unexpected-error doesn't leak.
- \`email.test.ts\` (7): unchanged, still green.

## Verification

- [x] \`npm run lint\` — clean
- [x] \`npm test\` — 46/46
- [x] \`npx tsc --noEmit\` — clean
- [x] \`npm run build\` — green, \`/api/recipes\` appears in the routes manifest as dynamic
- [x] \`grep -E "GITHUB_PAT|RECIPES_REPO|RECIPES_PATH" CLAUDE.md\` — 4 matches (Active Work entry + 3 env var bullets)

## Plan

Full plan with requirements trace, risks, and per-unit verification: [\`docs/plans/2026-04-23-001-feat-github-recipes-api-plan.md\`](docs/plans/2026-04-23-001-feat-github-recipes-api-plan.md).

## Test plan

- [ ] Set \`GITHUB_PAT\`, \`RECIPES_REPO\`, \`RECIPES_PATH\` in Vercel (Production + Preview + Development).
- [ ] \`curl\` \`/api/recipes\` against a real private repo with 2–3 sample recipes and confirm the response shape.
- [ ] Break each env var in turn locally (\`unset\`) and confirm the 500 response names the missing var.
- [ ] Point \`RECIPES_PATH\` at a wrong path and confirm the 502 response mentions all three env vars.
- [ ] Add a recipe with missing \`title\` and confirm the 502 response names the offending filename.

## Notes

- \`src/lib/resend.ts\` is untouched and still awaiting #70.
- No caching is in scope; revisit if #67's UI causes real latency.
- Fine-grained PAT scoped to just the recipes repo with Contents: Read is recommended over a classic token.