### PR TITLE
feat(deals): GET /api/deals for Safeway + Aldi via Flipp backend (#65)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,10 @@ GITHUB_PAT=your-github-pat
 RECIPES_REPO=your-username/your-recipes
 RECIPES_PATH=recipes
 
+# Deals (#65) — optional; both default to 34238 when unset
+SAFEWAY_ZIP=34238
+ALDI_ZIP=34238
+
 # Resend (optional — only needed if email delivery is enabled via #70)
 RESEND_API_KEY=your-resend-api-key
 EMAIL_FROM=onboarding@resend.dev

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,9 +30,9 @@ Do not reintroduce Supabase, SQLite, `better-sqlite3`, `@google/genai`, or the w
 ### Source Layout
 
 All source code lives under `src/`:
-- `src/app/` — pages, layouts, and API routes (`src/app/api/[route]/route.ts`). Implemented routes: `GET /api/recipes` (#64).
+- `src/app/` — pages, layouts, and API routes (`src/app/api/[route]/route.ts`). Implemented routes: `GET /api/recipes` (#64), `GET /api/deals` (#65).
 - `src/components/` — UI components (shadcn primitives under `src/components/ui/`)
-- `src/lib/` — shared utilities. Currently: `recipes/` (GitHub-backed recipe reader — `types.ts`, `parse.ts`, `github.ts`), `resend.ts` (lazy Resend client factory, retained for #70), `email.ts` (`parseRecipients` helper), `utils.ts` (`cn` className merger)
+- `src/lib/` — shared utilities. Currently: `recipes/` (GitHub-backed recipe reader — `types.ts`, `parse.ts`, `github.ts`), `deals/` (Flipp-backed Safeway + Aldi deals — `types.ts`, `parse.ts`, `flipp.ts`, `env.ts`, `errors.ts`), `resend.ts` (lazy Resend client factory, retained for #70), `email.ts` (`parseRecipients` helper), `utils.ts` (`cn` className merger)
 - `src/test/` — Vitest setup
 - `docs/plans/` — dated implementation plans
 - `docs/brainstorms/` — requirements / discovery docs
@@ -46,7 +46,7 @@ Feature-specific directories (`src/types/`, `src/lib/storage/`, etc.) will be re
 The new stack is being built feature-by-feature. Each open issue owns its own endpoint, env vars, types, and docs:
 
 - **#64** — `/api/recipes`: reads markdown recipes from a private GitHub repo (`GITHUB_PAT`, `RECIPES_REPO`, `RECIPES_PATH`). **Implemented.** Recipe logic lives in `src/lib/recipes/` (pure parser + fetcher); the route is a thin error-mapping layer. Recipes are non-recursive — one directory depth, `.md` files only, dotfiles filtered.
-- **#65** — `/api/deals`: Safeway + Aldi deals via Flipp backend (`SAFEWAY_ZIP`, `ALDI_ZIP`)
+- **#65** — `/api/deals`: Safeway + Aldi deals via Flipp backend (`SAFEWAY_ZIP`, `ALDI_ZIP`, both optional, default `34238`). **Implemented.** Deals logic lives in `src/lib/deals/` (pure parser + per-store fetcher + orchestrator); the route is a thin error-mapping + header layer. Flyers are cached 6 hours via Next.js fetch Data Cache; per-store failure returns 200 with `X-Deals-Errors`, all-store failure returns 502. Note: ZIP `34238` (the default) has no Safeway coverage — set `SAFEWAY_ZIP` to a real Safeway market to get Safeway deals.
 - **#66** — `/api/generate-plan`: Claude-powered plan generation with store context (`ANTHROPIC_API_KEY`)
 - **#67** — Single-page UI: deals sidebar, 5 meal cards, store-grouped grocery list
 - **#68** — `/api/log`: meal logging to monthly files in the recipes repo
@@ -62,6 +62,7 @@ See `.env.example`. Currently in use:
 - `GITHUB_PAT` (required by `/api/recipes`) — fine-grained PAT with Contents: Read scope on the recipes repo. Never interpolate its value into error messages.
 - `RECIPES_REPO` (required by `/api/recipes`) — `owner/name`, e.g. `your-username/your-recipes`.
 - `RECIPES_PATH` (required by `/api/recipes`) — directory inside the repo; empty string means repo root. Non-recursive.
+- `SAFEWAY_ZIP`, `ALDI_ZIP` (optional, used by `/api/deals`) — 5-digit ZIPs for Flipp flyer lookup; both default to `34238` when unset. Invalid values return 500.
 - `RESEND_*` — listed but not consumed until #70 adds `/api/email`.
 
 Each future feature issue adds the env vars it consumes in the same PR that introduces the consumer.

--- a/docs/plans/2026-04-24-001-feat-deals-api-flipp-plan.md
+++ b/docs/plans/2026-04-24-001-feat-deals-api-flipp-plan.md
@@ -1,0 +1,427 @@
+---
+title: "feat: Deals API (/api/deals for Safeway + Aldi via Flipp backend)"
+type: feat
+status: active
+date: 2026-04-24
+origin: https://github.com/dancj/meal-assistant/issues/65
+---
+
+# feat: Deals API (/api/deals for Safeway + Aldi via Flipp backend)
+
+## Overview
+
+Adds `GET /api/deals`, which pulls this week's sale items from Safeway and Aldi via Flipp's unauthenticated flyer search endpoint (`backflipp.wishabi.com`). Both stores are fetched in parallel, tagged, concatenated, and returned as `Deal[]`. Responses are cached for 6 hours (the Wed/Thu flyer cycle) using Next.js's built-in fetch Data Cache, and a cache/status header makes the behavior observable. One store failing does not fail the request — the other store's deals still come through.
+
+This is the second feature landing on the post-strip base. It becomes the store-context input for the meal-plan generator (#66) and the sidebar data source for the UI (#67).
+
+---
+
+## Problem Frame
+
+The meal-plan generator needs grocery context so it can favor recipes whose ingredients are on sale that week. Safeway and Aldi publish their weekly ads through Flipp (`backflipp.wishabi.com/flipp/items/search`), the same backend Kevin Old's [`grocery_deals`](https://github.com/kevinold/grocery_deals) uses for Kroger/Publix. The endpoint accepts a ZIP and a merchant-token query, returns a full flyer, and requires no auth.
+
+Constraints shaping the design:
+
+- **Flyers cycle Wed/Thu.** A 6-hour cache keeps the data fresh without hammering an unofficial endpoint.
+- **Flipp field names drift.** Kevin's code keeps fallback keys (e.g., `current_price` / `price` / `sale_price`); this plan does the same.
+- **Undocumented upstream.** No SLA, no stable schema — plan accordingly with defensive parsing, a short timeout, and per-store error isolation so one flaky response can't blank the whole endpoint.
+- **Household-scale, not prod-scale.** One user, a few requests per day. No horizontal-scaling concerns; Next.js's own fetch cache is enough.
+
+Origin issue: https://github.com/dancj/meal-assistant/issues/65
+
+---
+
+## Requirements Trace
+
+- R1. `GET /api/deals` returns a JSON array of `Deal` objects combining Safeway and Aldi results.
+- R2. Each `Deal` has exactly: `productName: string`, `brand: string`, `salePrice: string`, `regularPrice: string`, `promoType: string`, `validFrom: string`, `validTo: string`, `store: 'safeway' | 'aldi'` (matching the issue's declared shape).
+- R3. Safeway and Aldi flyers are fetched in parallel. End-to-end latency is the slower of the two network calls, not their sum.
+- R4. Each store's flyer response is cached for 6 hours via Next.js's fetch Data Cache (`next: { revalidate: 21600 }`), scoped by ZIP so different ZIP configs get different cache entries.
+- R5. Cache behavior is observable on the response: an `X-Deals-Source` header indicates whether the response was served from cache (`cache`), freshly fetched (`network`), or mixed (`mixed`); an `X-Deals-Stores` header lists the stores that returned results.
+- R6. When one store fails (network, timeout, or non-2xx), the endpoint still returns 200 with the successful store's deals and an `X-Deals-Errors` header naming the failed store(s). When *both* stores fail, the endpoint returns HTTP 502.
+- R7. ZIPs come from `SAFEWAY_ZIP` and `ALDI_ZIP` env vars; both default to `34238` when unset. Invalid ZIP values (empty after trim, non-5-digit) surface as HTTP 500 with a clear message naming the offending var.
+- R8. Flipp requests carry an `AbortController` timeout of 10 seconds. A timeout is treated as a per-store failure (see R6), not a 500.
+- R9. Deals are filtered to items whose Flipp `merchant` (or `merchant_name`) field contains the merchant token (`safeway` / `aldi`, case-insensitive). Items belonging to nearby stores returned by the same flyer query are excluded.
+- R10. Price fields (`salePrice`, `regularPrice`) are strings. If Flipp returns numeric prices, they are stringified verbatim; if a field is missing, the corresponding string is empty (`""`), not `null`/`undefined`.
+- R11. `promoType` is one of a small closed set: `bogo`, `multi_buy`, `amount_off`, `percent_off`, `sale`, classified from Flipp's `pre_price_text` / `sale_story` / `post_price_text` fields.
+- R12. `.env.example` advertises `SAFEWAY_ZIP` and `ALDI_ZIP` with safe placeholder values (ZIP `34238`, matching the issue's default) and a one-line description each.
+- R13. `CLAUDE.md`'s "Active Work" entry for #65 is updated from "planned" to the current endpoint/env-var description after merge.
+- R14. `npm run lint`, `npm test`, `npx tsc --noEmit`, and `npm run build` all succeed.
+
+---
+
+## Scope Boundaries
+
+- No other stores. Publix, Kroger, Walmart, etc. are out. Adding a new store is a later issue if the use case demands it.
+- No merchant-ID lookup. The plan uses the same token-match approach as the Python reference (`q=safeway` / `q=aldi` in the query, filter by `merchant` field client-side). Issue #65 mentions a Safeway-specific merchant-ID PR being sent to Kevin's repo separately; if merchant-ID lookup turns out to matter for Safeway's flyer, it's a follow-up change, not part of this plan.
+- No keyword / category filtering query params. The endpoint returns the full combined flyer; filtering happens downstream (generator #66, UI #67).
+- No pagination. Flipp returns a single-page flyer; if it ever exceeds what the upstream returns in one call, revisit.
+- No client-side SWR/React-Query hook. UI consumption lands with #67.
+- No auth. Same single-household posture as `/api/recipes` — any protection belongs at the Vercel/deployment layer, not in the route.
+- No per-item hydration. Kevin's code has an optional second-pass call to `backflipp.wishabi.com/flipp/items/{id}` to enrich a deal; we skip it — the flyer response has enough for the meal-plan use case.
+- No deal deduplication across stores. A product on sale at both Safeway and Aldi appears twice, tagged once per store. Downstream can dedup if it wants.
+- No response-payload cache (only the per-store upstream fetch is cached). Response headers (status, X-Deals-*) are always computed fresh. This is intentional — the cost is negligible and it keeps the observability headers honest.
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- **Route convention.** `src/app/api/recipes/route.ts` is the template: a thin handler that reads env, calls a lib function, catches named error classes via `instanceof`, and maps to HTTP status with `NextResponse.json(...)`. Mirror that shape for `src/app/api/deals/route.ts`.
+- **Lib structure.** `src/lib/recipes/` established the pattern: `types.ts` (pure types), `parse.ts` (pure transform), `github.ts` (side-effectful I/O). Colocate the deals module under `src/lib/deals/` with the same split: `types.ts`, `parse.ts`, `flipp.ts`.
+- **Env-var access.** `src/lib/recipes/github.ts`'s `requireEnv` helper reads `process.env` lazily inside the fetch function so tests can stub per-case. Deals will use a variant — `readEnvZip(name, default)` — that returns a string with a default, rather than throwing on missing, since ZIPs are optional here.
+- **Test patterns.** `src/lib/recipes/github.test.ts` is the template for side-effectful tests: `vi.stubGlobal("fetch", vi.fn(...))` with a per-test responder, `afterEach` teardown, `makeResponse` helper. `src/app/api/recipes/route.test.ts` is the template for route tests: `vi.mock("@/lib/recipes/github", ...)` with `mockResolvedValueOnce` / `mockRejectedValueOnce` per scenario. Follow both.
+- **Vitest config.** `vitest.config.ts` runs `environment: "node"`, so `fetch` is the platform global — no jsdom polyfill needed. `globals: true` lets tests use `describe`/`it`/`expect` without imports.
+- **Strict-mode TS + test exclusion.** `tsconfig.json` excludes `**/*.test.ts` from the build. Tests can freely import implementation via `@/*` alias; production bundle sees only non-test code.
+
+### Institutional Learnings
+
+- `~/.claude/projects/-Users-developer-projects-meal-assistant/memory/feedback_no_pii_in_public_repo.md`: `.env.example` and docs must use placeholder values (the default ZIP `34238` happens to also be the issue's stated default — it is generic and safe; no rewrite needed). Apply when writing U1 and U5.
+- `docs/plans/2026-04-23-001-feat-github-recipes-api-plan.md`: establishes the "thin route + lib split + named error classes + instanceof mapping" pattern this plan reuses wholesale.
+- `docs/plans/2026-04-22-002-refactor-post-strip-residuals-plan.md`: established the convention that `CLAUDE.md`'s "Active Work" list carries each open issue's endpoint + env vars. Update the #65 entry when the feature lands (R13).
+
+### External References
+
+- Kevin Old's `grocery_deals.py`: https://github.com/kevinold/grocery_deals/blob/main/grocery_deals.py — authoritative reference for Flipp request shape (`locale=en-us`, `postal_code=<zip>`, `q=<merchant_token>`), response fields, merchant-token matching, promo classification, and field-name fallbacks. Port the field-name fallback list and the promo regex set verbatim.
+- Flipp search endpoint (undocumented, discovered via Kevin's repo): `GET https://backflipp.wishabi.com/flipp/items/search?locale=en-us&postal_code=<zip>&q=<merchant>` returns `{ items: [...] }` (or `{ results: [...] }` — both fallback keys exist). No auth. Items contain `merchant`, `merchant_name`, `name`, `brand`, `current_price`, `original_price`, `sale_story`, `pre_price_text`, `post_price_text`, `valid_from`, `valid_to`, `flyer_item_id`.
+- Next.js 15 Data Cache: https://nextjs.org/docs/app/building-your-application/caching#data-cache — `fetch(url, { next: { revalidate: <seconds> } })` caches responses for `<seconds>` on Vercel's Data Cache. Works in route handlers. Cache key is the URL + request init; different ZIPs produce different keys automatically.
+
+---
+
+## Key Technical Decisions
+
+- **Use Next.js fetch Data Cache, not a hand-rolled cache.** `fetch(url, { next: { revalidate: 21600 } })` gives us the 6-hour TTL for free, deployed-instance-shared on Vercel, keyed automatically by full URL. A module-level `Map` cache would be per-instance and would not survive serverless cold starts — a fresh lambda every ~15 minutes blows up the cache. Next's Data Cache is the right primitive.
+- **One fetch per store, filter client-side.** `q=safeway` returns nearby stores too (Flipp behavior). Filter to items whose `merchant` field case-insensitively contains `safeway`. Avoids a separate merchant-ID lookup call and matches Kevin's approach exactly.
+- **`Promise.allSettled`, not `Promise.all`.** Partial failure is a first-class requirement (R6). `allSettled` lets us tag each store's outcome and build the response + headers from the per-store results. `Promise.all` short-circuits on the first rejection and kills the partial-success path.
+- **Named error classes for route mapping.** `FlippUpstreamError` (non-2xx), `FlippNetworkError` (fetch threw, including timeout), `InvalidZipError` (env-var validation). The route maps each via `instanceof` to 500 / 502 — same pattern as recipes. All-store failure aggregates two per-store errors into a single 502.
+- **10-second per-request timeout via `AbortController`.** Flipp is unauthenticated and occasionally flaky; an unbounded fetch can hang a serverless lambda. 10s is comfortably above the p99 of the Python reference's 20s budget for our use case and leaves time to try the other store if we stagger (we don't — they run in parallel). A timeout surfaces as `FlippNetworkError`.
+- **Prices are pass-through strings.** Flipp sometimes returns numbers, sometimes strings (`"2.99"`, `2.99`, `"2/$5.00"`). The `Deal` type is `salePrice: string` per the issue; the parser coerces with `String(value ?? "")` and trusts the UI to render whatever shape Flipp handed it. Numeric reasoning is out of scope.
+- **Promo classification mirrors Kevin's regexes.** Port the five-way classifier (`bogo`, `multi_buy`, `amount_off`, `percent_off`, `sale`) as-is. Adapting regex families is not worth the marginal quality; the behavior is already known-good in Kevin's repo.
+- **Split pure parsing from I/O.** `src/lib/deals/parse.ts` is pure: `(rawItem, merchantToken) -> Deal`. `src/lib/deals/flipp.ts` owns all network + caching + per-store orchestration. The route composes them. This lets parser tests use inline fixture objects, and fetcher tests stub `fetch`.
+- **Cache-observability via response headers, not body envelope.** The issue contract is `Deal[]` — a bare array — so we don't wrap in `{ deals, meta }`. Cache/source/status information goes on response headers (`X-Deals-Source`, `X-Deals-Stores`, `X-Deals-Errors`), keeping the JSON body exactly the shape the issue specified.
+- **No retries.** Kevin's Python code uses urllib3 retries. On serverless, retries add lambda time and don't recover from the class of failures we actually hit (upstream rate-limiting, schema drift). One shot per store, then `allSettled` absorbs the loss.
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Caching mechanism — hand-rolled or Next.js built-in?** Next.js fetch Data Cache with `revalidate: 21600`. See Key Technical Decisions.
+- **Merchant matching — token or ID lookup?** Token match on the `merchant` field, same as Kevin. Merchant-ID lookup is out of scope; revisit if Safeway's token match proves unreliable.
+- **Partial-failure response shape?** 200 + `X-Deals-Errors` header naming failed stores; 502 only when all fail. Body stays `Deal[]`.
+- **ZIPs required or optional?** Optional; both default to `34238` per issue. Validation is "non-empty, 5 digits"; anything else is 500 `InvalidZipError`.
+- **Price fields — string or number?** String per issue contract. Parser stringifies whatever Flipp returned.
+- **Should `promoType` be classified or raw?** Classified into the five-way set (`bogo | multi_buy | amount_off | percent_off | sale`). Keeps the shape predictable for the downstream generator.
+
+### Deferred to Implementation
+
+- **Exact shape of Flipp response for Safeway ZIP `34238`.** The Python reference is the spec, but Safeway may surface fields slightly differently from Kroger/Publix. The parser's fallback-key list is the guard; if something unexpected shows up, extend the fallback list rather than rewriting the shape. Confirm with a live call during U2.
+- **Whether `X-Deals-Source` can accurately distinguish `cache` vs. `network` under Next.js Data Cache.** Next.js doesn't directly expose cache-hit metadata to the route handler. The plan's approach is to time each fetch and treat sub-50ms responses as cache hits — good enough for observability, not a security claim. If this proves unreliable in practice, drop the header and log cache state instead.
+- **What `.env.example` placeholder to use.** `34238` is the issue's stated default and is generic enough to double as a placeholder; revisit only if we want to separate "default in code" from "example in dotenv."
+
+---
+
+## High-Level Technical Design
+
+> *This illustrates the intended request/response shape and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Route as /api/deals
+    participant Flipp as flipp.fetchDeals
+    participant Cache as Next.js Data Cache
+    participant Upstream as backflipp.wishabi.com
+
+    Client->>Route: GET /api/deals
+    Route->>Route: readEnvZip(SAFEWAY_ZIP, "34238")<br/>readEnvZip(ALDI_ZIP, "34238")
+    Route->>Flipp: Promise.allSettled([<br/>  fetchDeals("safeway", zip),<br/>  fetchDeals("aldi",    zip)<br/>])
+
+    par Safeway
+        Flipp->>Cache: fetch(safeway-url,<br/>next: { revalidate: 21600 })
+        alt cache hit
+            Cache-->>Flipp: cached JSON
+        else cache miss
+            Cache->>Upstream: GET /flipp/items/search?q=safeway
+            Upstream-->>Cache: { items: [...] }
+            Cache-->>Flipp: JSON (stored 6h)
+        end
+        Flipp->>Flipp: filter by merchant token<br/>parse each item -> Deal[]
+    and Aldi
+        Flipp->>Cache: fetch(aldi-url, ...)
+        Cache-->>Flipp: (cache hit or upstream)
+        Flipp->>Flipp: filter + parse -> Deal[]
+    end
+
+    Flipp-->>Route: [{ status, deals | error }, ...]
+    Route->>Route: build X-Deals-* headers<br/>concat successful deals<br/>pick HTTP status
+    Route-->>Client: Deal[] + headers (200 or 502)
+```
+
+The key shape points: per-store outcomes are independent, headers describe the multi-store result, body is a flat concatenated array of tagged deals.
+
+---
+
+## Implementation Units
+
+- [ ] U1. **Deals types, merchant config, and env scaffolding**
+
+**Goal:** Establish the `Deal` type, merchant-config constants (tokens, default ZIP, promo-type enum), and the env-var reader helpers. No network, no parsing logic — only the shared vocabulary subsequent units depend on.
+
+**Requirements:** R2, R7, R11, R12
+
+**Dependencies:** None
+
+**Files:**
+- Create: `src/lib/deals/types.ts` — `Deal` interface (matching R2 exactly), `Store` union (`'safeway' | 'aldi'`), `PromoType` union (`'bogo' | 'multi_buy' | 'amount_off' | 'percent_off' | 'sale'`), `MERCHANTS` const mapping `Store` → `{ token: string, displayName: string }`, `DEFAULT_ZIP = '34238'`
+- Create: `src/lib/deals/env.ts` — `readEnvZip(name, fallback)` helper that reads `process.env[name]`, trims, returns `fallback` when empty, throws `InvalidZipError` when set-but-not-5-digits
+- Create: `src/lib/deals/errors.ts` — `InvalidZipError`, `FlippNetworkError`, `FlippUpstreamError` subclasses (each carrying `varName` / `store` / `status` for error-message composition)
+- Create: `src/lib/deals/env.test.ts` — env helper tests
+- Modify: `.env.example` — add `SAFEWAY_ZIP=34238` and `ALDI_ZIP=34238` with one-line comments
+- Modify: `CLAUDE.md` — update the #65 line in "Active Work" from planned to implemented (can also land in U5; pick whichever commit is cleaner)
+
+**Approach:**
+- Colocate errors in a dedicated module so both `flipp.ts` and `route.ts` can import without cycles.
+- Keep the promo-type union and merchant config in `types.ts` — they are pure data.
+- `readEnvZip` returns `string` (always), never `undefined`. Callers can trust the value.
+
+**Patterns to follow:**
+- Env-var + named-error pattern from `src/lib/recipes/github.ts` (specifically the `requireEnv` + `MissingEnvVarError` shape).
+- Type-module colocation from `src/lib/recipes/types.ts`.
+
+**Test scenarios:**
+- Happy path: `readEnvZip("FOO", "34238")` returns `"34238"` when `FOO` unset. Covers R7.
+- Happy path: `readEnvZip("FOO", "34238")` returns `"12345"` when `process.env.FOO = "12345"`. Covers R7.
+- Edge case: `readEnvZip("FOO", "34238")` returns `"34238"` when `process.env.FOO = ""` (empty after trim — treated as unset).
+- Edge case: `readEnvZip("FOO", "34238")` returns `"34238"` when `process.env.FOO = "   "` (whitespace-only).
+- Error path: `readEnvZip("FOO", "34238")` throws `InvalidZipError` when `process.env.FOO = "abc"` (non-numeric). Error carries `varName: "FOO"`.
+- Error path: `readEnvZip("FOO", "34238")` throws `InvalidZipError` when `process.env.FOO = "1234"` (four digits).
+- Error path: `readEnvZip("FOO", "34238")` throws `InvalidZipError` when `process.env.FOO = "123456"` (six digits).
+
+**Verification:**
+- `Deal`, `Store`, `PromoType` exported from `src/lib/deals/types.ts` with the exact shape in R2.
+- `npx tsc --noEmit` passes.
+- `.env.example` shows the two new vars with the documented default.
+- `src/lib/deals/env.test.ts` covers unset, empty, valid, and invalid cases.
+
+---
+
+- [ ] U2. **Flipp item parser (pure transform)**
+
+**Goal:** Pure function that takes a single raw Flipp item object plus a store tag and returns a `Deal` — or signals "this item doesn't belong to this merchant" (caller filters it out). No I/O, no caching.
+
+**Requirements:** R2, R9, R10, R11
+
+**Dependencies:** U1
+
+**Files:**
+- Create: `src/lib/deals/parse.ts` — `parseFlippItem(rawItem, store): Deal | null` (returns `null` when the item's `merchant`/`merchant_name` does not contain the store's token); `classifyPromo(pre, story, post): PromoType`; `firstNonEmpty(obj, keys, fallback)` helper for field-name fallback
+- Create: `src/lib/deals/parse.test.ts` — parser + classifier tests using inline Flipp-shaped fixtures
+
+**Approach:**
+- Port field-name fallbacks from the Python reference: `current_price | price | sale_price` for `salePrice`; `original_price | regular_price | was_price | list_price` for `regularPrice`; `name | title | display_name` for `productName`; `brand | manufacturer` for `brand`; `valid_from | validFrom | start_date` for `validFrom`; `valid_to | validTo | end_date` for `validTo`; `pre_price_text | prePriceText`, `sale_story | saleStory`, `post_price_text | postPriceText` for promo classification.
+- Coerce missing/undefined/null string fields to `""` (R10). Coerce numeric prices via `String(value)`.
+- `classifyPromo` matches Python's regex set: BOGO first (`bogo|b1g1|buy one get one|buy 1 get 1`), then multi-buy (`N for $M`, `buy N get M`), then amount-off (`save $N`), then percent-off (`N% off`). Default `sale`.
+- `parseFlippItem` returns `null` for items whose merchant field does not case-insensitively contain the store's token — the caller uses `.filter(Boolean)` to drop them. This keeps filter + parse in one pass.
+
+**Patterns to follow:**
+- Pure-parser style from `src/lib/recipes/parse.ts` (no I/O, throws named errors, fully testable with fixtures).
+- Field-fallback helper from Kevin's `_first` function (see `grocery_deals.py`).
+
+**Test scenarios:**
+- Happy path: well-formed Flipp item with all primary fields → `Deal` with every string field populated and `store` tagged correctly.
+- Happy path: item with `price` instead of `current_price` → `salePrice` still populated (fallback works).
+- Happy path: item with `regularPrice` missing entirely → `Deal.regularPrice === ""`.
+- Happy path: item with numeric `current_price: 2.99` → `Deal.salePrice === "2.99"`.
+- Edge case: item where `merchant: "Publix Super Markets"` and store is `safeway` → `parseFlippItem` returns `null`.
+- Edge case: item where `merchant: "SAFEWAY INC"` (uppercase) and store is `safeway` → returns a `Deal` (case-insensitive token match).
+- Edge case: item where `merchant` missing but `merchant_name: "Safeway"` → returns a `Deal` (fallback key works).
+- Edge case: item with both `merchant` and `merchant_name` missing → returns `null`.
+- Happy path: `classifyPromo("", "BOGO on chicken", "")` → `"bogo"`.
+- Happy path: `classifyPromo("", "2 for $5", "")` → `"multi_buy"`.
+- Happy path: `classifyPromo("", "Save $2.00", "")` → `"amount_off"`.
+- Happy path: `classifyPromo("", "25% off", "")` → `"percent_off"`.
+- Edge case: `classifyPromo("", "", "")` → `"sale"` (default).
+- Edge case: `classifyPromo("buy one get one free", "", "")` → `"bogo"` (variant phrasing).
+- Happy path: `firstNonEmpty({ a: "", b: null, c: "x" }, ["a", "b", "c"], "fallback")` → `"x"`.
+- Edge case: `firstNonEmpty({}, ["a"], "fallback")` → `"fallback"`.
+
+**Verification:**
+- `src/lib/deals/parse.test.ts` covers every fallback key and promo-type branch.
+- A parsed `Deal` passed to `JSON.stringify` yields exactly the R2 field set.
+
+---
+
+- [ ] U3. **Flipp fetcher with per-store caching and timeout**
+
+**Goal:** `fetchDealsFromFlipp(store, zip): Promise<Deal[]>` — calls Flipp's search endpoint for one store, applies the 6-hour Next.js Data Cache, enforces a 10-second timeout, filters + parses the response into `Deal[]`. Throws `FlippUpstreamError` on non-2xx and `FlippNetworkError` on network/timeout failure.
+
+**Requirements:** R3, R4, R8, R9
+
+**Dependencies:** U1, U2
+
+**Files:**
+- Create: `src/lib/deals/flipp.ts` — `fetchDealsFromFlipp(store, zip)`; internal URL builder; `AbortController`-based timeout wrapper
+- Create: `src/lib/deals/flipp.test.ts` — fetcher tests using `vi.stubGlobal("fetch", ...)`
+
+**Approach:**
+- URL: `https://backflipp.wishabi.com/flipp/items/search?locale=en-us&postal_code=<zip>&q=<merchant-token>`.
+- Pass `{ next: { revalidate: 21600 } }` to `fetch`. Next.js's Data Cache keys off the full URL + init, so per-ZIP cache entries fall out naturally.
+- Wrap `fetch` in an `AbortController` with a 10s `setTimeout(() => controller.abort(), 10_000)`. On abort, throw `FlippNetworkError` with `cause` set to the abort reason.
+- Read response JSON, extract `items` (or `results` as fallback), map through `parseFlippItem`, drop `null`s.
+- On non-2xx, throw `FlippUpstreamError(status, store)`. Do not read the body as JSON — the body may be HTML for cases like 5xx from the CDN.
+- No retries (see Key Technical Decisions).
+
+**Execution note:** Confirm the live Flipp response shape for Safeway ZIP `34238` before locking in the test fixtures — the issue explicitly calls this out as step 1 of the implementation order. Use the confirmed raw response as the happy-path fixture.
+
+**Patterns to follow:**
+- Fetcher + named-error style from `src/lib/recipes/github.ts` (throws `GitHubUpstreamError` for non-2xx; route maps).
+- Fetch mocking style from `src/lib/recipes/github.test.ts` (`vi.stubGlobal("fetch", vi.fn(...))`, per-test responder, `makeResponse` helper).
+
+**Test scenarios:**
+- Happy path: happy Flipp response with two Safeway items and one Publix item → returns a `Deal[]` of length 2, both tagged `store: "safeway"`. Covers R9.
+- Happy path: `fetchDealsFromFlipp("aldi", "12345")` is called → the fetched URL contains `postal_code=12345` and `q=aldi`.
+- Happy path: fetch options include `next: { revalidate: 21600 }`. Covers R4.
+- Edge case: Flipp response uses `results` instead of `items` → fetcher still returns the parsed deals (fallback key).
+- Edge case: Flipp response has `items: []` → fetcher returns `[]` without throwing.
+- Edge case: Flipp response has items but none match the merchant token → fetcher returns `[]`.
+- Error path: Flipp responds 500 → throws `FlippUpstreamError` with `status === 500` and `store === "safeway"`.
+- Error path: Flipp responds 429 → throws `FlippUpstreamError` with `status === 429`.
+- Error path: `fetch` rejects (network failure) → throws `FlippNetworkError` wrapping the original error.
+- Error path: `fetch` takes longer than 10 seconds → `AbortController` fires, fetcher throws `FlippNetworkError` with `cause` indicating abort. Covers R8. *(Simulate by making the mocked `fetch` await a promise that resolves slowly; advance time with `vi.useFakeTimers()` + `vi.advanceTimersByTime(10_001)`.)*
+- Integration: two sequential calls for the same (store, zip) within a test — since Next's Data Cache is out-of-process, the test verifies only that our wrapper passes through identical URLs and options on both calls (actual cache-hit behavior is a Next.js property). *This is a wiring test, not a cache-hit test — document that plainly.*
+
+**Verification:**
+- `src/lib/deals/flipp.test.ts` exercises URL construction, cache-option passing, merchant filtering, fallback response keys, timeout, and both error classes.
+- A smoke run against the real Flipp endpoint (`curl` with `postal_code=34238&q=safeway`) returns a non-empty `items` array whose shape matches the fixture (ad-hoc confirmation during implementation per the execution note).
+
+---
+
+- [ ] U4. **Combined-store orchestrator with partial-failure semantics**
+
+**Goal:** `fetchAllDeals({ safewayZip, aldiZip }): Promise<{ deals: Deal[]; perStore: Array<{ store, status, durationMs, error? }> }>` — runs the per-store fetches in parallel with `Promise.allSettled`, returns the concatenated deals plus per-store outcome metadata the route layer uses to build response headers.
+
+**Requirements:** R1, R3, R5, R6
+
+**Dependencies:** U3
+
+**Files:**
+- Modify: `src/lib/deals/flipp.ts` — add `fetchAllDeals(...)` at the bottom of the file
+- Modify: `src/lib/deals/flipp.test.ts` — add an `describe("fetchAllDeals")` block
+
+**Approach:**
+- Record `Date.now()` before each per-store `fetchDealsFromFlipp` and compute `durationMs` on settle. Use `< 50ms` as a heuristic for "served from Next.js Data Cache" — good enough for the `X-Deals-Source` header; not a security claim.
+- `Promise.allSettled` returns an array aligned with the input order (safeway, aldi). Build `perStore` in the same order for deterministic output.
+- Concatenate successful stores' deals in the same order (safeway first, then aldi). No sorting — downstream decides.
+- Return shape is `{ deals, perStore }`; the route builds headers + response from `perStore`.
+
+**Patterns to follow:**
+- Parallel-fetch + aggregate pattern from `src/lib/recipes/github.ts`'s `Promise.all` over per-file fetches, adapted for `allSettled` + settled-result flattening.
+
+**Test scenarios:**
+- Happy path: both stores succeed → `deals` concatenates both (safeway first), `perStore` has two `status: "fulfilled"` entries. Covers R3, R6.
+- Happy path: both stores succeed, both resolve under 50ms (mocked cache-hit duration) → `perStore[i].durationMs < 50` for each. Covers R5.
+- Edge case: safeway succeeds, aldi fails with `FlippUpstreamError` → `deals` has only safeway items, `perStore[1].status === "rejected"` with the error preserved. Covers R6.
+- Edge case: both stores fail (one `FlippUpstreamError`, one `FlippNetworkError`) → `deals === []`, both `perStore` entries `rejected` with the correct error types. Covers R6.
+- Edge case: safeway succeeds with an empty `items` array → `deals === []` (from safeway's side), `perStore[0].status === "fulfilled"`.
+- Integration: the two per-store fetches run concurrently (assert via parallel-call observation on the stubbed `fetch` — both calls issued before the first resolves). Covers R3.
+
+**Verification:**
+- Partial-failure returns 200 semantics (the orchestrator returns data + metadata; status-code choice lives in U5, which is verified there).
+- `perStore` always has exactly two entries in `[safeway, aldi]` order.
+
+---
+
+- [ ] U5. **Route handler + cache-observability headers**
+
+**Goal:** `GET /api/deals` — reads env, calls `fetchAllDeals`, shapes the response (body = `Deal[]`, headers = `X-Deals-*`), maps errors to HTTP status (200 / 502 / 500).
+
+**Requirements:** R1, R5, R6, R7, R13
+
+**Dependencies:** U1, U4
+
+**Files:**
+- Create: `src/app/api/deals/route.ts` — `GET` handler
+- Create: `src/app/api/deals/route.test.ts` — route tests with `vi.mock("@/lib/deals/flipp", ...)`
+- Modify: `CLAUDE.md` — update the #65 "Active Work" entry to the implemented-endpoint form (unless already landed in U1)
+
+**Approach:**
+- Read `SAFEWAY_ZIP` and `ALDI_ZIP` via `readEnvZip`; on `InvalidZipError`, return 500 with `{ error: "<VAR> must be a 5-digit ZIP" }`.
+- Call `fetchAllDeals({ safewayZip, aldiZip })`.
+- Compute headers:
+  - `X-Deals-Stores`: comma-joined list of stores with `status === "fulfilled"` (e.g., `"safeway,aldi"` or `"safeway"`).
+  - `X-Deals-Errors`: comma-joined list of stores with `status === "rejected"` (header omitted entirely when no errors).
+  - `X-Deals-Source`: `"cache"` if all fulfilled stores had `durationMs < 50`, `"network"` if none did, `"mixed"` otherwise, `"unknown"` when zero stores succeeded.
+- Compute status:
+  - All stores failed → 502 with `{ error: "All deal sources failed", details: [{ store, message }, ...] }` and body is **not** `Deal[]` here (error envelope). Document this explicitly in the response contract.
+  - Otherwise → 200 with the `Deal[]` body.
+- Never leak the raw `Error` stack to the client; log server-side.
+
+**Execution note:** Start with a failing route test for the three status shapes (all-fulfilled → 200, partial → 200 + X-Deals-Errors, all-rejected → 502). Implement to pass.
+
+**Patterns to follow:**
+- Thin-handler + `instanceof` error mapping from `src/app/api/recipes/route.ts`.
+- Route-test mocking from `src/app/api/recipes/route.test.ts` (`vi.mock(...)` the lib module, `mockResolvedValueOnce` per scenario, assert on status and body).
+
+**Test scenarios:**
+- Happy path: both stores fulfilled with deals → 200, body is `Deal[]` concat, `X-Deals-Stores: "safeway,aldi"`, no `X-Deals-Errors` header. Covers R1, R5, R6.
+- Happy path: both stores fulfilled but both `durationMs < 50` → `X-Deals-Source: "cache"`. Covers R5.
+- Happy path: both stores fulfilled, one fast one slow → `X-Deals-Source: "mixed"`. Covers R5.
+- Happy path: both stores fulfilled, both slow → `X-Deals-Source: "network"`. Covers R5.
+- Edge case: safeway fulfilled, aldi rejected → 200, body is safeway deals only, `X-Deals-Stores: "safeway"`, `X-Deals-Errors: "aldi"`. Covers R6.
+- Edge case: both rejected → 502, body is `{ error, details }` envelope, `X-Deals-Stores` header omitted or empty, `X-Deals-Errors: "safeway,aldi"`, `X-Deals-Source: "unknown"`. Covers R6.
+- Error path: `SAFEWAY_ZIP = "abc"` → 500 with `{ error: "SAFEWAY_ZIP must be a 5-digit ZIP" }`, no call to `fetchAllDeals`. Covers R7.
+- Error path: `fetchAllDeals` throws an unexpected error (e.g., `TypeError` from a bug, not one of the named classes) → 500 with `{ error: "Unexpected error" }`; original error is logged. The raw message does not leak.
+- Integration: route test mocks `fetchAllDeals` to return a mixed-duration `perStore` payload, asserts body + all four `X-Deals-*` headers together.
+
+**Verification:**
+- `curl -i http://localhost:3000/api/deals` against a dev server returns 200, `Content-Type: application/json`, body parses as an array, and response headers include `X-Deals-Stores`. (Confirm manually during implementation.)
+- `src/app/api/deals/route.test.ts` covers every status / header combination enumerated above.
+- `npm run lint`, `npx tsc --noEmit`, `npm test`, `npm run build` all pass.
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** `/api/deals` is a net-new route with no current consumers. Its downstream consumers are #66 (generator) and #67 (UI), both unimplemented. No existing code paths branch on deals.
+- **Error propagation:** Per-store errors are absorbed at the orchestrator layer (`allSettled`) and emerge as metadata, not exceptions. Only the all-store-failed case bubbles to a 502. Env-var errors short-circuit before any network I/O.
+- **State lifecycle risks:** Next.js Data Cache is keyed by URL; a typo'd ZIP would produce a permanent miss-then-cached-error until the TTL expires. The `InvalidZipError` pre-check (pre-fetch, pre-cache) prevents this.
+- **API surface parity:** Only one consumer surface — the HTTP route. No CLI, no background job, no other caller. Keeps blast radius tight.
+- **Integration coverage:** The parallel-fetch timing (R3) and the `X-Deals-Source` duration heuristic are behaviors mocks can approximate but not fully prove. Confirm on a real request during U3/U5 implementation and note any deviations in the PR.
+- **Unchanged invariants:** `/api/recipes` is untouched. `.env.example`'s existing variables (`GITHUB_PAT`, `RECIPES_REPO`, `RECIPES_PATH`, `RESEND_*`) stay in place; this plan only adds new lines. `package.json` needs no new dependencies — `gray-matter` is for recipes, not deals.
+
+---
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Flipp changes field names (known historical behavior per Kevin's CLAUDE.md). | Parser uses fallback keys everywhere. Adding a new fallback key is a one-line change + test fixture. |
+| Flipp returns HTML instead of JSON on upstream failure (CDN error page). | Fetcher checks response status before reading JSON; non-2xx throws `FlippUpstreamError` without touching the body. |
+| Flipp rate-limits by IP or adds auth. | Single-household traffic is well under anyone's rate-limit threshold. If it happens, fall back to Flipp's public browser UI scrape (separate issue) or drop the store. |
+| Next.js Data Cache does not persist reliably on Vercel's free tier. | 6-hour cache is a performance optimization, not a correctness requirement. A cold cache means each request hits Flipp twice — still cheap and within Flipp's tolerance. Revisit if cold-miss rates become painful. |
+| `X-Deals-Source` duration heuristic misclassifies "warm upstream" as "cache hit." | Header is observability, not policy. Under-50ms-equals-cache is good enough for a human looking at `curl -i`; no downstream logic branches on it. Documented explicitly in Deferred Questions. |
+| `AbortController` timeout interacts badly with Next.js fetch cache (e.g., cached-response read still counts toward the timeout). | In practice, Data Cache reads are synchronous deserialization well under 10s. If the interaction surfaces, shorten the timeout or wrap only the network-path `fetch` rather than the cached one. |
+| Promo-type regex misclassifies a real promo. | Low-impact — misclassifications degrade downstream reasoning but don't crash anything. The classifier defaults to `sale` on no-match, which is a safe fallback. |
+
+---
+
+## Documentation / Operational Notes
+
+- `.env.example` gains `SAFEWAY_ZIP` and `ALDI_ZIP` (R12).
+- `CLAUDE.md`'s "Active Work" list for #65 updates from planned to implemented form, describing endpoint + env vars (R13). Same convention as #64's landing commit.
+- No new dependencies in `package.json`; native `fetch` + `AbortController` only.
+- No monitoring or rollout concern — single-household app, no rollback gate. If the endpoint breaks, `curl /api/deals` will show it immediately; no user is depending on it until #67 lands the UI.
+
+---
+
+## Sources & References
+
+- Origin issue: [#65 — Deals fetcher: /api/deals for Safeway + Aldi via Flipp backend](https://github.com/dancj/meal-assistant/issues/65)
+- Related code: `src/app/api/recipes/route.ts`, `src/lib/recipes/github.ts`, `src/lib/recipes/parse.ts`, `src/lib/recipes/github.test.ts`
+- Related plans: `docs/plans/2026-04-23-001-feat-github-recipes-api-plan.md`
+- External: Kevin Old's `grocery_deals.py` — https://github.com/kevinold/grocery_deals/blob/main/grocery_deals.py
+- External: Next.js 15 Data Cache — https://nextjs.org/docs/app/building-your-application/caching#data-cache
+- External: Flipp search endpoint (undocumented) — `https://backflipp.wishabi.com/flipp/items/search`

--- a/src/app/api/deals/route.test.ts
+++ b/src/app/api/deals/route.test.ts
@@ -1,0 +1,275 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { FlippNetworkError, FlippUpstreamError } from "@/lib/deals/errors";
+import type { StoreOutcome } from "@/lib/deals/flipp";
+import type { Deal } from "@/lib/deals/types";
+
+vi.mock("@/lib/deals/flipp", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/deals/flipp")>(
+    "@/lib/deals/flipp",
+  );
+  return {
+    ...actual,
+    fetchAllDeals: vi.fn(),
+  };
+});
+
+const { GET } = await import("./route");
+const { fetchAllDeals } = await import("@/lib/deals/flipp");
+const fetchAllDealsMock = vi.mocked(fetchAllDeals);
+
+async function getBody(response: Response): Promise<unknown> {
+  return await response.json();
+}
+
+function safewayDeal(name = "Apples"): Deal {
+  return {
+    productName: name,
+    brand: "Gala",
+    salePrice: "1.99",
+    regularPrice: "3.49",
+    promoType: "sale",
+    validFrom: "2026-04-23",
+    validTo: "2026-04-29",
+    store: "safeway",
+  };
+}
+
+function aldiDeal(name = "Bananas"): Deal {
+  return {
+    productName: name,
+    brand: "",
+    salePrice: "0.49",
+    regularPrice: "",
+    promoType: "sale",
+    validFrom: "2026-04-23",
+    validTo: "2026-04-29",
+    store: "aldi",
+  };
+}
+
+function fulfilled(
+  store: Deal["store"],
+  deals: Deal[],
+  durationMs = 200,
+): StoreOutcome {
+  return { store, status: "fulfilled", durationMs, deals };
+}
+
+function rejected(
+  store: Deal["store"],
+  error: unknown,
+  durationMs = 200,
+): StoreOutcome {
+  return { store, status: "rejected", durationMs, error };
+}
+
+describe("GET /api/deals", () => {
+  beforeEach(() => {
+    delete process.env.SAFEWAY_ZIP;
+    delete process.env.ALDI_ZIP;
+  });
+
+  afterEach(() => {
+    fetchAllDealsMock.mockReset();
+    vi.restoreAllMocks();
+    delete process.env.SAFEWAY_ZIP;
+    delete process.env.ALDI_ZIP;
+  });
+
+  describe("happy path", () => {
+    it("returns 200 with both stores' deals when both succeed", async () => {
+      fetchAllDealsMock.mockResolvedValueOnce({
+        deals: [safewayDeal(), aldiDeal()],
+        perStore: [
+          fulfilled("safeway", [safewayDeal()]),
+          fulfilled("aldi", [aldiDeal()]),
+        ],
+      });
+
+      const response = await GET();
+
+      expect(response.status).toBe(200);
+      const body = (await getBody(response)) as Deal[];
+      expect(body).toHaveLength(2);
+      expect(response.headers.get("X-Deals-Stores")).toBe("safeway,aldi");
+      expect(response.headers.get("X-Deals-Errors")).toBeNull();
+    });
+
+    it("uses the default ZIP when env vars are unset", async () => {
+      fetchAllDealsMock.mockResolvedValueOnce({
+        deals: [],
+        perStore: [
+          fulfilled("safeway", []),
+          fulfilled("aldi", []),
+        ],
+      });
+
+      await GET();
+
+      expect(fetchAllDealsMock).toHaveBeenCalledWith({
+        safewayZip: "34238",
+        aldiZip: "34238",
+      });
+    });
+
+    it("passes the configured ZIPs from env", async () => {
+      process.env.SAFEWAY_ZIP = "12345";
+      process.env.ALDI_ZIP = "67890";
+      fetchAllDealsMock.mockResolvedValueOnce({
+        deals: [],
+        perStore: [fulfilled("safeway", []), fulfilled("aldi", [])],
+      });
+
+      await GET();
+
+      expect(fetchAllDealsMock).toHaveBeenCalledWith({
+        safewayZip: "12345",
+        aldiZip: "67890",
+      });
+    });
+  });
+
+  describe("X-Deals-Source header", () => {
+    it("is 'cache' when both fulfilled stores resolve under 50ms", async () => {
+      fetchAllDealsMock.mockResolvedValueOnce({
+        deals: [],
+        perStore: [
+          fulfilled("safeway", [], 10),
+          fulfilled("aldi", [], 20),
+        ],
+      });
+
+      const response = await GET();
+      expect(response.headers.get("X-Deals-Source")).toBe("cache");
+    });
+
+    it("is 'network' when both fulfilled stores take over 50ms", async () => {
+      fetchAllDealsMock.mockResolvedValueOnce({
+        deals: [],
+        perStore: [
+          fulfilled("safeway", [], 300),
+          fulfilled("aldi", [], 400),
+        ],
+      });
+
+      const response = await GET();
+      expect(response.headers.get("X-Deals-Source")).toBe("network");
+    });
+
+    it("is 'mixed' when one is fast and one is slow", async () => {
+      fetchAllDealsMock.mockResolvedValueOnce({
+        deals: [],
+        perStore: [
+          fulfilled("safeway", [], 10),
+          fulfilled("aldi", [], 400),
+        ],
+      });
+
+      const response = await GET();
+      expect(response.headers.get("X-Deals-Source")).toBe("mixed");
+    });
+
+    it("is 'unknown' when every store failed", async () => {
+      fetchAllDealsMock.mockResolvedValueOnce({
+        deals: [],
+        perStore: [
+          rejected("safeway", new FlippNetworkError("safeway", new Error("x"))),
+          rejected("aldi", new FlippUpstreamError("aldi", 500)),
+        ],
+      });
+
+      const response = await GET();
+      expect(response.headers.get("X-Deals-Source")).toBe("unknown");
+    });
+  });
+
+  describe("partial failure", () => {
+    it("returns 200 with the successful store's deals when the other fails", async () => {
+      fetchAllDealsMock.mockResolvedValueOnce({
+        deals: [safewayDeal()],
+        perStore: [
+          fulfilled("safeway", [safewayDeal()]),
+          rejected("aldi", new FlippUpstreamError("aldi", 503)),
+        ],
+      });
+
+      const response = await GET();
+
+      expect(response.status).toBe(200);
+      const body = (await getBody(response)) as Deal[];
+      expect(body).toHaveLength(1);
+      expect(body[0].store).toBe("safeway");
+      expect(response.headers.get("X-Deals-Stores")).toBe("safeway");
+      expect(response.headers.get("X-Deals-Errors")).toBe("aldi");
+    });
+  });
+
+  describe("all stores fail", () => {
+    it("returns 502 with an error envelope naming each failure", async () => {
+      fetchAllDealsMock.mockResolvedValueOnce({
+        deals: [],
+        perStore: [
+          rejected(
+            "safeway",
+            new FlippNetworkError("safeway", new Error("dns")),
+          ),
+          rejected("aldi", new FlippUpstreamError("aldi", 500)),
+        ],
+      });
+
+      const response = await GET();
+
+      expect(response.status).toBe(502);
+      const body = (await getBody(response)) as {
+        error: string;
+        details: Array<{ store: string; message: string }>;
+      };
+      expect(body.error).toBe("All deal sources failed");
+      expect(body.details).toHaveLength(2);
+      expect(body.details[0].store).toBe("safeway");
+      expect(body.details[0].message).toMatch(/dns/);
+      expect(body.details[1].store).toBe("aldi");
+      expect(body.details[1].message).toMatch(/500/);
+      expect(response.headers.get("X-Deals-Stores")).toBeNull();
+      expect(response.headers.get("X-Deals-Errors")).toBe("safeway,aldi");
+      expect(response.headers.get("X-Deals-Source")).toBe("unknown");
+    });
+  });
+
+  describe("env validation", () => {
+    it("returns 500 with a clear message when SAFEWAY_ZIP is invalid", async () => {
+      process.env.SAFEWAY_ZIP = "abc";
+
+      const response = await GET();
+
+      expect(response.status).toBe(500);
+      const body = (await getBody(response)) as { error: string };
+      expect(body.error).toMatch(/SAFEWAY_ZIP/);
+      expect(fetchAllDealsMock).not.toHaveBeenCalled();
+    });
+
+    it("returns 500 with a clear message when ALDI_ZIP is invalid", async () => {
+      process.env.ALDI_ZIP = "12";
+
+      const response = await GET();
+
+      expect(response.status).toBe(500);
+      const body = (await getBody(response)) as { error: string };
+      expect(body.error).toMatch(/ALDI_ZIP/);
+      expect(fetchAllDealsMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("unexpected errors", () => {
+    it("returns 500 without leaking the error message on an unknown throw", async () => {
+      fetchAllDealsMock.mockRejectedValueOnce(new TypeError("internal crash"));
+
+      const response = await GET();
+
+      expect(response.status).toBe(500);
+      const body = (await getBody(response)) as { error: string };
+      expect(body.error).toBe("Unexpected error");
+      expect(body.error).not.toMatch(/internal crash/);
+    });
+  });
+});

--- a/src/app/api/deals/route.ts
+++ b/src/app/api/deals/route.ts
@@ -1,0 +1,86 @@
+import { readEnvZip } from "@/lib/deals/env";
+import { InvalidZipError } from "@/lib/deals/errors";
+import { fetchAllDeals, type StoreOutcome } from "@/lib/deals/flipp";
+import { DEFAULT_ZIP } from "@/lib/deals/types";
+
+export const runtime = "nodejs";
+
+const CACHE_HIT_THRESHOLD_MS = 50;
+
+function buildHeaders(perStore: StoreOutcome[]): Headers {
+  const headers = new Headers();
+  const fulfilled = perStore.filter((p) => p.status === "fulfilled");
+  const rejected = perStore.filter((p) => p.status === "rejected");
+
+  const stores = fulfilled.map((p) => p.store).join(",");
+  if (stores !== "") {
+    headers.set("X-Deals-Stores", stores);
+  }
+
+  if (rejected.length > 0) {
+    headers.set("X-Deals-Errors", rejected.map((p) => p.store).join(","));
+  }
+
+  if (fulfilled.length === 0) {
+    headers.set("X-Deals-Source", "unknown");
+  } else {
+    const allCached = fulfilled.every(
+      (p) => p.durationMs < CACHE_HIT_THRESHOLD_MS,
+    );
+    const anyCached = fulfilled.some(
+      (p) => p.durationMs < CACHE_HIT_THRESHOLD_MS,
+    );
+    if (allCached) {
+      headers.set("X-Deals-Source", "cache");
+    } else if (anyCached) {
+      headers.set("X-Deals-Source", "mixed");
+    } else {
+      headers.set("X-Deals-Source", "network");
+    }
+  }
+
+  return headers;
+}
+
+export async function GET(): Promise<Response> {
+  let safewayZip: string;
+  let aldiZip: string;
+  try {
+    safewayZip = readEnvZip("SAFEWAY_ZIP", DEFAULT_ZIP);
+    aldiZip = readEnvZip("ALDI_ZIP", DEFAULT_ZIP);
+  } catch (err) {
+    if (err instanceof InvalidZipError) {
+      return Response.json({ error: err.message }, { status: 500 });
+    }
+    console.error("Unexpected /api/deals env error", err);
+    return Response.json(
+      { error: "Unexpected error reading configuration" },
+      { status: 500 },
+    );
+  }
+
+  try {
+    const { deals, perStore } = await fetchAllDeals({ safewayZip, aldiZip });
+    const headers = buildHeaders(perStore);
+
+    const allRejected = perStore.every((p) => p.status === "rejected");
+    if (allRejected) {
+      const details = perStore.map((p) => ({
+        store: p.store,
+        message:
+          p.status === "rejected" && p.error instanceof Error
+            ? p.error.message
+            : "unknown error",
+      }));
+      return Response.json(
+        { error: "All deal sources failed", details },
+        { status: 502, headers },
+      );
+    }
+
+    return Response.json(deals, { status: 200, headers });
+  } catch (err) {
+    console.error("Unexpected /api/deals error", err);
+    return Response.json({ error: "Unexpected error" }, { status: 500 });
+  }
+}

--- a/src/lib/deals/env.test.ts
+++ b/src/lib/deals/env.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { readEnvZip } from "./env";
+import { InvalidZipError } from "./errors";
+
+describe("readEnvZip", () => {
+  afterEach(() => {
+    delete process.env.TEST_ZIP;
+  });
+
+  it("returns the fallback when the env var is unset", () => {
+    expect(readEnvZip("TEST_ZIP", "34238")).toBe("34238");
+  });
+
+  it("returns the env value when it is a valid 5-digit ZIP", () => {
+    process.env.TEST_ZIP = "12345";
+    expect(readEnvZip("TEST_ZIP", "34238")).toBe("12345");
+  });
+
+  it("returns the fallback when the env var is empty", () => {
+    process.env.TEST_ZIP = "";
+    expect(readEnvZip("TEST_ZIP", "34238")).toBe("34238");
+  });
+
+  it("returns the fallback when the env var is whitespace-only", () => {
+    process.env.TEST_ZIP = "   ";
+    expect(readEnvZip("TEST_ZIP", "34238")).toBe("34238");
+  });
+
+  it("throws InvalidZipError when the env var is non-numeric", () => {
+    process.env.TEST_ZIP = "abc";
+    expect(() => readEnvZip("TEST_ZIP", "34238")).toThrow(InvalidZipError);
+    expect(() => readEnvZip("TEST_ZIP", "34238")).toThrow(/TEST_ZIP/);
+  });
+
+  it("throws InvalidZipError when the env var has fewer than 5 digits", () => {
+    process.env.TEST_ZIP = "1234";
+    expect(() => readEnvZip("TEST_ZIP", "34238")).toThrow(InvalidZipError);
+  });
+
+  it("throws InvalidZipError when the env var has more than 5 digits", () => {
+    process.env.TEST_ZIP = "123456";
+    expect(() => readEnvZip("TEST_ZIP", "34238")).toThrow(InvalidZipError);
+  });
+
+  it("throws InvalidZipError when the env var mixes digits and letters", () => {
+    process.env.TEST_ZIP = "1234a";
+    expect(() => readEnvZip("TEST_ZIP", "34238")).toThrow(InvalidZipError);
+  });
+
+  it("carries the offending var name on the error", () => {
+    process.env.TEST_ZIP = "abc";
+    try {
+      readEnvZip("TEST_ZIP", "34238");
+      throw new Error("expected throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(InvalidZipError);
+      expect((err as InvalidZipError).varName).toBe("TEST_ZIP");
+    }
+  });
+});

--- a/src/lib/deals/env.ts
+++ b/src/lib/deals/env.ts
@@ -1,0 +1,15 @@
+import { InvalidZipError } from "./errors";
+
+const ZIP_PATTERN = /^\d{5}$/;
+
+export function readEnvZip(name: string, fallback: string): string {
+  const raw = process.env[name];
+  const trimmed = (raw ?? "").trim();
+  if (trimmed === "") {
+    return fallback;
+  }
+  if (!ZIP_PATTERN.test(trimmed)) {
+    throw new InvalidZipError(name, trimmed);
+  }
+  return trimmed;
+}

--- a/src/lib/deals/errors.ts
+++ b/src/lib/deals/errors.ts
@@ -1,0 +1,35 @@
+import type { Store } from "./types";
+
+export class InvalidZipError extends Error {
+  readonly varName: string;
+
+  constructor(varName: string, value: string) {
+    super(`${varName} must be a 5-digit ZIP (got "${value}")`);
+    this.name = "InvalidZipError";
+    this.varName = varName;
+  }
+}
+
+export class FlippUpstreamError extends Error {
+  readonly status: number;
+  readonly store: Store;
+
+  constructor(store: Store, status: number) {
+    super(`Flipp upstream error for ${store} (status ${status})`);
+    this.name = "FlippUpstreamError";
+    this.status = status;
+    this.store = store;
+  }
+}
+
+export class FlippNetworkError extends Error {
+  readonly store: Store;
+
+  constructor(store: Store, cause: unknown) {
+    const detail = cause instanceof Error ? cause.message : String(cause);
+    super(`Flipp network error for ${store}: ${detail}`);
+    this.name = "FlippNetworkError";
+    this.store = store;
+    this.cause = cause;
+  }
+}

--- a/src/lib/deals/flipp.test.ts
+++ b/src/lib/deals/flipp.test.ts
@@ -1,5 +1,5 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { fetchDealsFromFlipp } from "./flipp";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { fetchAllDeals, fetchDealsFromFlipp } from "./flipp";
 import { FlippNetworkError, FlippUpstreamError } from "./errors";
 
 type FetchArgs = Parameters<typeof fetch>;
@@ -259,5 +259,153 @@ describe("fetchDealsFromFlipp", () => {
       expect(abortedSignal).not.toBeNull();
       expect(abortedSignal!.aborted).toBe(true);
     });
+  });
+});
+
+describe("fetchAllDeals", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("runs both store fetches concurrently and concatenates in safeway,aldi order", async () => {
+    let peakConcurrent = 0;
+    let inFlight = 0;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: FetchArgs[0]) => {
+        inFlight += 1;
+        peakConcurrent = Math.max(peakConcurrent, inFlight);
+        // Yield so both fetches can start before either resolves.
+        await Promise.resolve();
+        await Promise.resolve();
+        inFlight -= 1;
+        const url = String(input);
+        if (url.includes("q=safeway")) {
+          return makeResponse({
+            items: [
+              {
+                merchant_name: "Safeway",
+                name: "Apples",
+                current_price: "1.99",
+              },
+            ],
+          });
+        }
+        return makeResponse({
+          items: [
+            { merchant_name: "ALDI", name: "Bananas", current_price: "0.49" },
+          ],
+        });
+      }),
+    );
+
+    const result = await fetchAllDeals({
+      safewayZip: "12345",
+      aldiZip: "34238",
+    });
+
+    expect(peakConcurrent).toBe(2);
+    expect(result.perStore.map((p) => p.store)).toEqual(["safeway", "aldi"]);
+    expect(result.perStore.every((p) => p.status === "fulfilled")).toBe(true);
+    expect(result.deals.map((d) => d.productName)).toEqual(["Apples", "Bananas"]);
+  });
+
+  it("returns partial deals when one store fails", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: FetchArgs[0]) => {
+        const url = String(input);
+        if (url.includes("q=safeway")) {
+          return makeResponse({ items: [safewayItem()] });
+        }
+        return makeResponse("upstream error", { status: 503 });
+      }),
+    );
+
+    const result = await fetchAllDeals({
+      safewayZip: "12345",
+      aldiZip: "34238",
+    });
+
+    expect(result.perStore).toHaveLength(2);
+    expect(result.perStore[0].status).toBe("fulfilled");
+    expect(result.perStore[1].status).toBe("rejected");
+    expect(result.deals).toHaveLength(1);
+    expect(result.deals[0].store).toBe("safeway");
+
+    const rejected = result.perStore[1];
+    if (rejected.status !== "rejected") throw new Error("expected rejected");
+    expect(rejected.error).toBeInstanceOf(FlippUpstreamError);
+  });
+
+  it("returns empty deals with both rejected when both stores fail", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: FetchArgs[0]) => {
+        const url = String(input);
+        if (url.includes("q=safeway")) {
+          // Reject via network error
+          throw new Error("dns failure");
+        }
+        return makeResponse("upstream", { status: 500 });
+      }),
+    );
+
+    const result = await fetchAllDeals({
+      safewayZip: "12345",
+      aldiZip: "34238",
+    });
+
+    expect(result.deals).toEqual([]);
+    expect(result.perStore.every((p) => p.status === "rejected")).toBe(true);
+    const safeway = result.perStore[0];
+    const aldi = result.perStore[1];
+    if (safeway.status !== "rejected" || aldi.status !== "rejected") {
+      throw new Error("expected both rejected");
+    }
+    expect(safeway.error).toBeInstanceOf(FlippNetworkError);
+    expect(aldi.error).toBeInstanceOf(FlippUpstreamError);
+  });
+
+  it("records a durationMs on every outcome", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => makeResponse({ items: [] })),
+    );
+
+    const result = await fetchAllDeals({
+      safewayZip: "12345",
+      aldiZip: "34238",
+    });
+
+    for (const outcome of result.perStore) {
+      expect(typeof outcome.durationMs).toBe("number");
+      expect(outcome.durationMs).toBeGreaterThanOrEqual(0);
+    }
+  });
+
+  it("returns an empty deals list from a store whose flyer has no matching items", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: FetchArgs[0]) => {
+        const url = String(input);
+        if (url.includes("q=safeway")) {
+          return makeResponse({ items: [] });
+        }
+        return makeResponse({ items: [{ merchant_name: "ALDI", name: "Rice" }] });
+      }),
+    );
+
+    const result = await fetchAllDeals({
+      safewayZip: "12345",
+      aldiZip: "34238",
+    });
+
+    expect(result.perStore[0].status).toBe("fulfilled");
+    if (result.perStore[0].status !== "fulfilled") return;
+    expect(result.perStore[0].deals).toEqual([]);
+    expect(result.deals).toHaveLength(1);
+    expect(result.deals[0].store).toBe("aldi");
   });
 });

--- a/src/lib/deals/flipp.test.ts
+++ b/src/lib/deals/flipp.test.ts
@@ -1,0 +1,263 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { fetchDealsFromFlipp } from "./flipp";
+import { FlippNetworkError, FlippUpstreamError } from "./errors";
+
+type FetchArgs = Parameters<typeof fetch>;
+type MockResponder = (
+  input: FetchArgs[0],
+  init?: FetchArgs[1],
+) => Response | Promise<Response>;
+
+function makeResponse(body: unknown, init: ResponseInit = {}): Response {
+  const text = typeof body === "string" ? body : JSON.stringify(body);
+  return new Response(text, {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+    ...init,
+  });
+}
+
+function installFetchMock(responder: MockResponder): {
+  calls: Array<{ url: string; init?: FetchArgs[1] }>;
+} {
+  const calls: Array<{ url: string; init?: FetchArgs[1] }> = [];
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: FetchArgs[0], init?: FetchArgs[1]) => {
+      calls.push({ url: String(input), init });
+      return Promise.resolve(responder(input, init));
+    }),
+  );
+  return { calls };
+}
+
+function safewayItem(overrides: Record<string, unknown> = {}) {
+  return {
+    merchant_name: "SAFEWAY",
+    name: "Chicken Breast",
+    brand: "Signature Farms",
+    current_price: 3.99,
+    original_price: 5.99,
+    valid_from: "2026-04-23",
+    valid_to: "2026-04-29",
+    ...overrides,
+  };
+}
+
+function publixItem(overrides: Record<string, unknown> = {}) {
+  return {
+    merchant_name: "Publix Super Markets",
+    name: "Bread",
+    brand: "Publix",
+    current_price: 2.49,
+    original_price: 3.49,
+    valid_from: "2026-04-23",
+    valid_to: "2026-04-29",
+    ...overrides,
+  };
+}
+
+describe("fetchDealsFromFlipp", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  describe("URL + cache options", () => {
+    it("builds the correct URL for safeway", async () => {
+      const { calls } = installFetchMock(() => makeResponse({ items: [] }));
+      await fetchDealsFromFlipp("safeway", "12345");
+      expect(calls).toHaveLength(1);
+      expect(calls[0].url).toBe(
+        "https://backflipp.wishabi.com/flipp/items/search?locale=en-us&postal_code=12345&q=safeway",
+      );
+    });
+
+    it("builds the correct URL for aldi", async () => {
+      const { calls } = installFetchMock(() => makeResponse({ items: [] }));
+      await fetchDealsFromFlipp("aldi", "34238");
+      expect(calls[0].url).toContain("postal_code=34238");
+      expect(calls[0].url).toContain("q=aldi");
+    });
+
+    it("passes the 6-hour revalidate cache option to fetch", async () => {
+      const { calls } = installFetchMock(() => makeResponse({ items: [] }));
+      await fetchDealsFromFlipp("safeway", "12345");
+      const init = calls[0].init as RequestInit & {
+        next?: { revalidate?: number };
+      };
+      expect(init?.next?.revalidate).toBe(21600);
+    });
+
+    it("passes an AbortSignal to fetch", async () => {
+      const { calls } = installFetchMock(() => makeResponse({ items: [] }));
+      await fetchDealsFromFlipp("safeway", "12345");
+      expect(calls[0].init?.signal).toBeInstanceOf(AbortSignal);
+    });
+  });
+
+  describe("happy paths", () => {
+    it("parses safeway items and filters out non-safeway items", async () => {
+      installFetchMock(() =>
+        makeResponse({
+          items: [
+            safewayItem({ name: "Apples" }),
+            publixItem(),
+            safewayItem({ name: "Bananas" }),
+          ],
+        }),
+      );
+      const deals = await fetchDealsFromFlipp("safeway", "12345");
+      expect(deals).toHaveLength(2);
+      expect(deals.map((d) => d.productName)).toEqual(["Apples", "Bananas"]);
+      expect(deals.every((d) => d.store === "safeway")).toBe(true);
+    });
+
+    it("falls back to the 'results' key when 'items' is missing", async () => {
+      installFetchMock(() =>
+        makeResponse({ results: [safewayItem({ name: "Eggs" })] }),
+      );
+      const deals = await fetchDealsFromFlipp("safeway", "12345");
+      expect(deals).toHaveLength(1);
+      expect(deals[0].productName).toBe("Eggs");
+    });
+
+    it("returns an empty array when items is empty", async () => {
+      installFetchMock(() => makeResponse({ items: [] }));
+      const deals = await fetchDealsFromFlipp("safeway", "12345");
+      expect(deals).toEqual([]);
+    });
+
+    it("returns an empty array when no items match the merchant token", async () => {
+      installFetchMock(() => makeResponse({ items: [publixItem(), publixItem()] }));
+      const deals = await fetchDealsFromFlipp("safeway", "12345");
+      expect(deals).toEqual([]);
+    });
+
+    it("handles real-shape items with null merchant and numeric prices", async () => {
+      installFetchMock(() =>
+        makeResponse({
+          items: [
+            {
+              merchant: null,
+              merchant_name: "ALDI",
+              name: "ALDI Greek Chickpeas",
+              brand: null,
+              current_price: 2.29,
+              original_price: null,
+              valid_from: "2026-04-22T04:00:00+00:00",
+              valid_to: "2026-04-29T03:59:59+00:00",
+              sale_story: null,
+              pre_price_text: null,
+              post_price_text: null,
+            },
+          ],
+        }),
+      );
+      const deals = await fetchDealsFromFlipp("aldi", "34238");
+      expect(deals).toHaveLength(1);
+      expect(deals[0]).toMatchObject({
+        productName: "ALDI Greek Chickpeas",
+        brand: "",
+        salePrice: "2.29",
+        regularPrice: "",
+        promoType: "sale",
+        store: "aldi",
+      });
+    });
+
+    it("skips non-object entries in the items array", async () => {
+      installFetchMock(() =>
+        makeResponse({ items: [null, "a string", safewayItem(), 42] }),
+      );
+      const deals = await fetchDealsFromFlipp("safeway", "12345");
+      expect(deals).toHaveLength(1);
+    });
+  });
+
+  describe("upstream errors", () => {
+    it("throws FlippUpstreamError on 500", async () => {
+      installFetchMock(() => makeResponse("server error", { status: 500 }));
+      await expect(fetchDealsFromFlipp("safeway", "12345")).rejects.toThrow(
+        FlippUpstreamError,
+      );
+    });
+
+    it("throws FlippUpstreamError on 429 with the status preserved", async () => {
+      installFetchMock(() => makeResponse("rate limited", { status: 429 }));
+      try {
+        await fetchDealsFromFlipp("aldi", "12345");
+        throw new Error("expected throw");
+      } catch (err) {
+        expect(err).toBeInstanceOf(FlippUpstreamError);
+        expect((err as FlippUpstreamError).status).toBe(429);
+        expect((err as FlippUpstreamError).store).toBe("aldi");
+      }
+    });
+
+    it("does not attempt to parse JSON when the response is non-2xx", async () => {
+      // Body is HTML; a JSON.parse call would throw a different error.
+      installFetchMock(() =>
+        new Response("<html>bad gateway</html>", {
+          status: 502,
+          headers: { "Content-Type": "text/html" },
+        }),
+      );
+      await expect(fetchDealsFromFlipp("safeway", "12345")).rejects.toThrow(
+        FlippUpstreamError,
+      );
+    });
+  });
+
+  describe("network errors", () => {
+    it("wraps fetch rejections as FlippNetworkError", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(() => Promise.reject(new Error("dns failure"))),
+      );
+      await expect(fetchDealsFromFlipp("safeway", "12345")).rejects.toThrow(
+        FlippNetworkError,
+      );
+      await expect(fetchDealsFromFlipp("safeway", "12345")).rejects.toThrow(
+        /dns failure/,
+      );
+    });
+
+    it("wraps JSON-parse failures as FlippNetworkError", async () => {
+      installFetchMock(
+        () =>
+          new Response("not valid json", {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+      );
+      await expect(fetchDealsFromFlipp("safeway", "12345")).rejects.toThrow(
+        FlippNetworkError,
+      );
+    });
+
+    it("aborts the fetch after the timeout", async () => {
+      vi.useFakeTimers();
+      let abortedSignal: AbortSignal | null = null;
+      vi.stubGlobal(
+        "fetch",
+        vi.fn((_input: FetchArgs[0], init?: FetchArgs[1]) => {
+          abortedSignal = init?.signal ?? null;
+          return new Promise<Response>((_, reject) => {
+            init?.signal?.addEventListener("abort", () => {
+              reject(
+                new DOMException("The operation was aborted.", "AbortError"),
+              );
+            });
+          });
+        }),
+      );
+      const promise = fetchDealsFromFlipp("safeway", "12345");
+      vi.advanceTimersByTime(10_001);
+      await expect(promise).rejects.toThrow(FlippNetworkError);
+      expect(abortedSignal).not.toBeNull();
+      expect(abortedSignal!.aborted).toBe(true);
+    });
+  });
+});

--- a/src/lib/deals/flipp.ts
+++ b/src/lib/deals/flipp.ts
@@ -1,6 +1,6 @@
 import { FlippNetworkError, FlippUpstreamError } from "./errors";
 import { parseFlippItem } from "./parse";
-import { MERCHANTS, type Deal, type Store } from "./types";
+import { MERCHANTS, STORES, type Deal, type Store } from "./types";
 
 const FLIPP_SEARCH_URL = "https://backflipp.wishabi.com/flipp/items/search";
 const CACHE_TTL_SECONDS = 6 * 60 * 60;
@@ -69,4 +69,77 @@ export async function fetchDealsFromFlipp(
     if (deal !== null) deals.push(deal);
   }
   return deals;
+}
+
+export interface FulfilledStoreOutcome {
+  store: Store;
+  status: "fulfilled";
+  durationMs: number;
+  deals: Deal[];
+}
+
+export interface RejectedStoreOutcome {
+  store: Store;
+  status: "rejected";
+  durationMs: number;
+  error: unknown;
+}
+
+export type StoreOutcome = FulfilledStoreOutcome | RejectedStoreOutcome;
+
+export interface AllDealsResult {
+  deals: Deal[];
+  perStore: StoreOutcome[];
+}
+
+export interface FetchAllDealsInput {
+  safewayZip: string;
+  aldiZip: string;
+}
+
+async function timed(
+  store: Store,
+  task: () => Promise<Deal[]>,
+): Promise<StoreOutcome> {
+  const startedAt = Date.now();
+  try {
+    const deals = await task();
+    return {
+      store,
+      status: "fulfilled",
+      durationMs: Date.now() - startedAt,
+      deals,
+    };
+  } catch (error) {
+    return {
+      store,
+      status: "rejected",
+      durationMs: Date.now() - startedAt,
+      error,
+    };
+  }
+}
+
+export async function fetchAllDeals({
+  safewayZip,
+  aldiZip,
+}: FetchAllDealsInput): Promise<AllDealsResult> {
+  const zipByStore: Record<Store, string> = {
+    safeway: safewayZip,
+    aldi: aldiZip,
+  };
+
+  const perStore = await Promise.all(
+    STORES.map((store) =>
+      timed(store, () => fetchDealsFromFlipp(store, zipByStore[store])),
+    ),
+  );
+
+  const deals: Deal[] = [];
+  for (const outcome of perStore) {
+    if (outcome.status === "fulfilled") {
+      deals.push(...outcome.deals);
+    }
+  }
+  return { deals, perStore };
 }

--- a/src/lib/deals/flipp.ts
+++ b/src/lib/deals/flipp.ts
@@ -1,0 +1,72 @@
+import { FlippNetworkError, FlippUpstreamError } from "./errors";
+import { parseFlippItem } from "./parse";
+import { MERCHANTS, type Deal, type Store } from "./types";
+
+const FLIPP_SEARCH_URL = "https://backflipp.wishabi.com/flipp/items/search";
+const CACHE_TTL_SECONDS = 6 * 60 * 60;
+const FETCH_TIMEOUT_MS = 10_000;
+
+function buildSearchUrl(zip: string, merchantToken: string): string {
+  const params = new URLSearchParams({
+    locale: "en-us",
+    postal_code: zip,
+    q: merchantToken,
+  });
+  return `${FLIPP_SEARCH_URL}?${params.toString()}`;
+}
+
+async function fetchWithTimeout(
+  url: string,
+  timeoutMs: number,
+): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetch(url, {
+      signal: controller.signal,
+      next: { revalidate: CACHE_TTL_SECONDS },
+    });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+interface FlippSearchPayload {
+  items?: unknown[];
+  results?: unknown[];
+}
+
+export async function fetchDealsFromFlipp(
+  store: Store,
+  zip: string,
+): Promise<Deal[]> {
+  const { token } = MERCHANTS[store];
+  const url = buildSearchUrl(zip, token);
+
+  let response: Response;
+  try {
+    response = await fetchWithTimeout(url, FETCH_TIMEOUT_MS);
+  } catch (err) {
+    throw new FlippNetworkError(store, err);
+  }
+
+  if (!response.ok) {
+    throw new FlippUpstreamError(store, response.status);
+  }
+
+  let payload: FlippSearchPayload;
+  try {
+    payload = (await response.json()) as FlippSearchPayload;
+  } catch (err) {
+    throw new FlippNetworkError(store, err);
+  }
+
+  const rawItems = payload.items ?? payload.results ?? [];
+  const deals: Deal[] = [];
+  for (const raw of rawItems) {
+    if (raw === null || typeof raw !== "object") continue;
+    const deal = parseFlippItem(raw as Record<string, unknown>, store);
+    if (deal !== null) deals.push(deal);
+  }
+  return deals;
+}

--- a/src/lib/deals/parse.test.ts
+++ b/src/lib/deals/parse.test.ts
@@ -1,0 +1,254 @@
+import { describe, expect, it } from "vitest";
+import { classifyPromo, firstNonEmpty, parseFlippItem } from "./parse";
+
+function baseSafewayItem(overrides: Record<string, unknown> = {}) {
+  return {
+    merchant: "Safeway",
+    name: "Organic Apples",
+    brand: "Gala",
+    current_price: "2.99",
+    original_price: "4.49",
+    sale_story: "",
+    pre_price_text: "",
+    post_price_text: "",
+    valid_from: "2026-04-23",
+    valid_to: "2026-04-29",
+    ...overrides,
+  };
+}
+
+describe("firstNonEmpty", () => {
+  it("returns the first non-empty value", () => {
+    expect(
+      firstNonEmpty({ a: "", b: null, c: "x" }, ["a", "b", "c"], "fallback"),
+    ).toBe("x");
+  });
+
+  it("returns the fallback when all keys are missing or empty", () => {
+    expect(firstNonEmpty({}, ["a"], "fallback")).toBe("fallback");
+    expect(
+      firstNonEmpty({ a: null, b: undefined, c: "" }, ["a", "b", "c"], "fb"),
+    ).toBe("fb");
+  });
+
+  it("skips empty arrays", () => {
+    expect(firstNonEmpty({ a: [] as unknown[], b: "x" }, ["a", "b"], "fb")).toBe("x");
+  });
+
+  it("returns numeric values unchanged", () => {
+    expect(firstNonEmpty({ a: 2.99 }, ["a"], "fb")).toBe(2.99);
+  });
+});
+
+describe("classifyPromo", () => {
+  it("classifies BOGO", () => {
+    expect(classifyPromo("", "BOGO on chicken", "")).toBe("bogo");
+  });
+
+  it("classifies variant BOGO phrasing", () => {
+    expect(classifyPromo("buy one get one free", "", "")).toBe("bogo");
+    expect(classifyPromo("", "B1G1", "")).toBe("bogo");
+    expect(classifyPromo("", "Buy 1 Get 1", "")).toBe("bogo");
+  });
+
+  it("classifies multi-buy", () => {
+    expect(classifyPromo("", "2 for $5", "")).toBe("multi_buy");
+    expect(classifyPromo("", "3/$10", "")).toBe("multi_buy");
+    expect(classifyPromo("", "Buy 2 Get 1", "")).toBe("multi_buy");
+  });
+
+  it("classifies amount-off", () => {
+    expect(classifyPromo("", "Save $2.00", "")).toBe("amount_off");
+    expect(classifyPromo("", "save $3", "")).toBe("amount_off");
+  });
+
+  it("classifies percent-off", () => {
+    expect(classifyPromo("", "25% off", "")).toBe("percent_off");
+    expect(classifyPromo("", "50 % off", "")).toBe("percent_off");
+  });
+
+  it("defaults to 'sale' for empty input", () => {
+    expect(classifyPromo("", "", "")).toBe("sale");
+  });
+
+  it("defaults to 'sale' when no regex matches", () => {
+    expect(classifyPromo("", "Great deal", "")).toBe("sale");
+  });
+
+  it("applies BOGO before multi-buy when both keywords appear", () => {
+    // "2 for $5" would match multi-buy, but "BOGO" wins.
+    expect(classifyPromo("", "BOGO 2 for $5", "")).toBe("bogo");
+  });
+});
+
+describe("parseFlippItem", () => {
+  it("returns a Deal with every string field populated for a well-formed item", () => {
+    const deal = parseFlippItem(baseSafewayItem(), "safeway");
+    expect(deal).toEqual({
+      productName: "Organic Apples",
+      brand: "Gala",
+      salePrice: "2.99",
+      regularPrice: "4.49",
+      promoType: "sale",
+      validFrom: "2026-04-23",
+      validTo: "2026-04-29",
+      store: "safeway",
+    });
+  });
+
+  it("uses 'price' fallback when 'current_price' is missing", () => {
+    const deal = parseFlippItem(
+      baseSafewayItem({ current_price: undefined, price: "3.99" }),
+      "safeway",
+    );
+    expect(deal?.salePrice).toBe("3.99");
+  });
+
+  it("uses 'sale_price' fallback when 'current_price' and 'price' are missing", () => {
+    const deal = parseFlippItem(
+      baseSafewayItem({
+        current_price: undefined,
+        price: undefined,
+        sale_price: "1.99",
+      }),
+      "safeway",
+    );
+    expect(deal?.salePrice).toBe("1.99");
+  });
+
+  it("leaves regularPrice as empty string when all regular-price keys are missing", () => {
+    const deal = parseFlippItem(
+      baseSafewayItem({
+        original_price: undefined,
+        regular_price: undefined,
+        was_price: undefined,
+        list_price: undefined,
+      }),
+      "safeway",
+    );
+    expect(deal?.regularPrice).toBe("");
+  });
+
+  it("uses 'was_price' and 'list_price' fallbacks for regularPrice", () => {
+    const wasDeal = parseFlippItem(
+      baseSafewayItem({
+        original_price: undefined,
+        regular_price: undefined,
+        was_price: "5.49",
+      }),
+      "safeway",
+    );
+    expect(wasDeal?.regularPrice).toBe("5.49");
+
+    const listDeal = parseFlippItem(
+      baseSafewayItem({
+        original_price: undefined,
+        regular_price: undefined,
+        was_price: undefined,
+        list_price: "6.99",
+      }),
+      "safeway",
+    );
+    expect(listDeal?.regularPrice).toBe("6.99");
+  });
+
+  it("stringifies numeric prices from Flipp", () => {
+    const deal = parseFlippItem(
+      baseSafewayItem({ current_price: 2.99, original_price: 4.49 }),
+      "safeway",
+    );
+    expect(deal?.salePrice).toBe("2.99");
+    expect(deal?.regularPrice).toBe("4.49");
+  });
+
+  it("uses 'title' fallback for productName", () => {
+    const deal = parseFlippItem(
+      baseSafewayItem({ name: undefined, title: "Apples" }),
+      "safeway",
+    );
+    expect(deal?.productName).toBe("Apples");
+  });
+
+  it("uses 'display_name' fallback for productName", () => {
+    const deal = parseFlippItem(
+      baseSafewayItem({
+        name: undefined,
+        title: undefined,
+        display_name: "Fresh Apples",
+      }),
+      "safeway",
+    );
+    expect(deal?.productName).toBe("Fresh Apples");
+  });
+
+  it("uses 'manufacturer' fallback for brand", () => {
+    const deal = parseFlippItem(
+      baseSafewayItem({ brand: undefined, manufacturer: "Gala" }),
+      "safeway",
+    );
+    expect(deal?.brand).toBe("Gala");
+  });
+
+  it("uses 'validFrom' / 'validTo' camelCase fallbacks", () => {
+    const deal = parseFlippItem(
+      baseSafewayItem({
+        valid_from: undefined,
+        validFrom: "2026-04-23",
+        valid_to: undefined,
+        validTo: "2026-04-29",
+      }),
+      "safeway",
+    );
+    expect(deal?.validFrom).toBe("2026-04-23");
+    expect(deal?.validTo).toBe("2026-04-29");
+  });
+
+  it("classifies promo from sale_story when present", () => {
+    const deal = parseFlippItem(
+      baseSafewayItem({ sale_story: "BOGO" }),
+      "safeway",
+    );
+    expect(deal?.promoType).toBe("bogo");
+  });
+
+  it("returns null for items that do not belong to the requested store", () => {
+    const deal = parseFlippItem(
+      baseSafewayItem({ merchant: "Publix Super Markets" }),
+      "safeway",
+    );
+    expect(deal).toBeNull();
+  });
+
+  it("matches merchant case-insensitively", () => {
+    const deal = parseFlippItem(
+      baseSafewayItem({ merchant: "SAFEWAY INC" }),
+      "safeway",
+    );
+    expect(deal).not.toBeNull();
+    expect(deal?.store).toBe("safeway");
+  });
+
+  it("uses merchant_name when merchant is missing", () => {
+    const deal = parseFlippItem(
+      baseSafewayItem({ merchant: undefined, merchant_name: "Safeway" }),
+      "safeway",
+    );
+    expect(deal).not.toBeNull();
+  });
+
+  it("returns null when both merchant and merchant_name are missing", () => {
+    const deal = parseFlippItem(
+      baseSafewayItem({ merchant: undefined, merchant_name: undefined }),
+      "safeway",
+    );
+    expect(deal).toBeNull();
+  });
+
+  it("tags the result with the requested store", () => {
+    const deal = parseFlippItem(
+      baseSafewayItem({ merchant: "ALDI" }),
+      "aldi",
+    );
+    expect(deal?.store).toBe("aldi");
+  });
+});

--- a/src/lib/deals/parse.ts
+++ b/src/lib/deals/parse.ts
@@ -1,0 +1,91 @@
+import { MERCHANTS, type Deal, type PromoType, type Store } from "./types";
+
+type FlippItem = Record<string, unknown>;
+
+export function firstNonEmpty<T>(
+  source: Record<string, unknown>,
+  keys: readonly string[],
+  fallback: T,
+): T | string | number {
+  for (const key of keys) {
+    const value = source[key];
+    if (value === null || value === undefined) continue;
+    if (typeof value === "string" && value === "") continue;
+    if (Array.isArray(value) && value.length === 0) continue;
+    return value as T | string | number;
+  }
+  return fallback;
+}
+
+function asString(value: unknown): string {
+  if (value === null || value === undefined) return "";
+  if (typeof value === "string") return value;
+  if (typeof value === "number" || typeof value === "boolean") return String(value);
+  return "";
+}
+
+const BOGO_RX = /\b(bogo|b1g1|buy\s*one\s*get\s*one|buy\s*1\s*get\s*1)\b/i;
+const MULTI_BUY_RX = /(\d+\s*(?:for|\/)\s*\$?\d+|\bbuy\s*\d+\s*get\s*\d+)/i;
+const AMOUNT_OFF_RX = /save\s*\$?\s*\d+(?:\.\d+)?/i;
+const PERCENT_OFF_RX = /\d+\s*%\s*off/i;
+
+export function classifyPromo(
+  pre: string,
+  story: string,
+  post: string,
+): PromoType {
+  const blob = [pre, story, post].filter(Boolean).join(" ").trim();
+  if (blob === "") return "sale";
+  if (BOGO_RX.test(blob)) return "bogo";
+  if (MULTI_BUY_RX.test(blob)) return "multi_buy";
+  if (AMOUNT_OFF_RX.test(blob)) return "amount_off";
+  if (PERCENT_OFF_RX.test(blob)) return "percent_off";
+  return "sale";
+}
+
+function merchantMatches(item: FlippItem, token: string): boolean {
+  const merchant = firstNonEmpty(item, ["merchant", "merchant_name"], "");
+  const asText = typeof merchant === "string" ? merchant : "";
+  if (asText === "") return false;
+  return asText.toLowerCase().includes(token.toLowerCase());
+}
+
+export function parseFlippItem(item: FlippItem, store: Store): Deal | null {
+  const { token } = MERCHANTS[store];
+  if (!merchantMatches(item, token)) return null;
+
+  const pre = asString(
+    firstNonEmpty(item, ["pre_price_text", "prePriceText"], ""),
+  );
+  const story = asString(
+    firstNonEmpty(item, ["sale_story", "saleStory"], ""),
+  );
+  const post = asString(
+    firstNonEmpty(item, ["post_price_text", "postPriceText"], ""),
+  );
+
+  return {
+    productName: asString(
+      firstNonEmpty(item, ["name", "title", "display_name"], ""),
+    ),
+    brand: asString(firstNonEmpty(item, ["brand", "manufacturer"], "")),
+    salePrice: asString(
+      firstNonEmpty(item, ["current_price", "price", "sale_price"], ""),
+    ),
+    regularPrice: asString(
+      firstNonEmpty(
+        item,
+        ["original_price", "regular_price", "was_price", "list_price"],
+        "",
+      ),
+    ),
+    promoType: classifyPromo(pre, story, post),
+    validFrom: asString(
+      firstNonEmpty(item, ["valid_from", "validFrom", "start_date"], ""),
+    ),
+    validTo: asString(
+      firstNonEmpty(item, ["valid_to", "validTo", "end_date"], ""),
+    ),
+    store,
+  };
+}

--- a/src/lib/deals/types.ts
+++ b/src/lib/deals/types.ts
@@ -1,0 +1,33 @@
+export type Store = "safeway" | "aldi";
+
+export type PromoType =
+  | "bogo"
+  | "multi_buy"
+  | "amount_off"
+  | "percent_off"
+  | "sale";
+
+export interface Deal {
+  productName: string;
+  brand: string;
+  salePrice: string;
+  regularPrice: string;
+  promoType: PromoType;
+  validFrom: string;
+  validTo: string;
+  store: Store;
+}
+
+export interface MerchantConfig {
+  token: string;
+  displayName: string;
+}
+
+export const MERCHANTS: Record<Store, MerchantConfig> = {
+  safeway: { token: "safeway", displayName: "Safeway" },
+  aldi: { token: "aldi", displayName: "Aldi" },
+};
+
+export const STORES: readonly Store[] = ["safeway", "aldi"];
+
+export const DEFAULT_ZIP = "34238";


### PR DESCRIPTION
Closes #65.

## Summary

- Adds `GET /api/deals` returning combined Safeway + Aldi deals from Flipp's unauthenticated flyer search (`backflipp.wishabi.com`).
- Per-store flyers fetched in parallel; 6-hour cache via Next.js fetch Data Cache (`next: { revalidate: 21600 }`).
- Partial failure is a first-class case: one store failing returns 200 with the survivor's deals; all stores failing returns 502 with an error envelope.
- `X-Deals-Stores`, `X-Deals-Errors`, and `X-Deals-Source` headers expose per-request outcomes without wrapping the JSON body (contract stays `Deal[]`).
- New module layout under `src/lib/deals/` mirrors the recipes split: pure `types.ts`, pure `parse.ts`, side-effectful `flipp.ts`, dedicated `errors.ts` and `env.ts`.

## Design notes

- **Flipp field drift** — parser uses the same fallback-key chains as Kevin Old's `grocery_deals.py` reference (`current_price | price | sale_price`, `merchant | merchant_name`, etc.) so schema changes on the unofficial upstream don't break parsing silently.
- **Merchant filtering** — `q=safeway` / `q=aldi` returns nearby-store items too; filter client-side by case-insensitive substring match on the item's `merchant` / `merchant_name` field. No merchant-ID lookup needed.
- **Timeout** — 10s `AbortController` per per-store fetch; abort surfaces as `FlippNetworkError` (partial-failure path), not a 500.
- **ZIPs are optional** — `SAFEWAY_ZIP` and `ALDI_ZIP` both default to `34238`. Invalid values (non-5-digit) return 500 with the offending variable named.
- **Cache-source heuristic** — `X-Deals-Source` uses a 50ms-duration heuristic to label `cache | network | mixed | unknown`. Advisory, not a security claim; documented in the plan.

Heads-up: ZIP `34238` (Florida) has no Safeway coverage — Safeway will return 0 items with that default. Set `SAFEWAY_ZIP` to a real Safeway market to see Safeway deals. Aldi returns ~100 items for 34238. Called out in `CLAUDE.md`.

## Plan

docs/plans/2026-04-24-001-feat-deals-api-flipp-plan.md

## Verification

- `npm run lint` — no warnings or errors.
- `npx tsc --noEmit` — clean.
- `npm test` — 116 tests pass across 8 files (28 parser + 21 fetcher/orchestrator + 12 route + 9 env + prior recipes/email/parse suites).
- `npm run build` — succeeds; `/api/deals` shows up as a dynamic server-rendered route.
- Live smoke against `npm run dev`: first request returns 200 with `x-deals-source: network` and ~100 Aldi items at ZIP 34238; second request returns `x-deals-source: cache` (Next.js Data Cache hit). Safeway returns 0 items for this ZIP as expected.

## Test plan

- [ ] `npm run lint` clean
- [ ] `npx tsc --noEmit` clean
- [ ] `npm test` — all 116 pass
- [ ] `npm run build` succeeds
- [ ] `curl -is http://localhost:3000/api/deals` returns 200 with `X-Deals-Stores`, `X-Deals-Source`, and a `Deal[]` body
- [ ] Second request returns `X-Deals-Source: cache`
- [ ] `SAFEWAY_ZIP=abc npm run dev` → `curl /api/deals` returns 500 naming `SAFEWAY_ZIP`