### PR TITLE
chore: add Vitest + Cypress TDD skills and CLAUDE.md guidance

### DIFF
--- a/.claude/skills/meal-assistant/tdd-cypress/SKILL.md
+++ b/.claude/skills/meal-assistant/tdd-cypress/SKILL.md
@@ -1,0 +1,246 @@
+---
+name: meal-assistant:tdd-cypress
+description: TDD workflow for end-to-end tests using Cypress in the meal-assistant codebase. Use when implementing user-facing features, fixing UI bugs, or adding e2e test coverage with a test-first approach. Triggers on "e2e TDD", "cypress TDD", "test-driven e2e", "e2e test first", or when the user requests test-driven development for end-to-end or integration-level browser tests.
+---
+
+# Test-Driven Development with Cypress E2E
+
+Integrate red-green-refactor discipline into feature implementation using Cypress for end-to-end tests in the meal-assistant codebase.
+
+## Philosophy
+
+E2E tests verify that the system works as a user would experience it. In TDD, the e2e test is written first to define the acceptance criteria, then the feature is built to satisfy it.
+
+E2E TDD works at a coarser granularity than unit TDD — each cycle covers a user-visible behavior or workflow, not an internal function.
+
+## When to Use
+
+**Apply Cypress TDD when:**
+
+- Implementing new user-facing features or workflows on `/` (and any future page)
+- Fixing bugs that are observable in the browser (loading states, regenerate flow, swap flow, thumbs interaction)
+- Adding acceptance tests for existing features
+- Building flows that span multiple components and API calls (mount → fetch trio → render → click → POST)
+
+**Skip Cypress TDD when:**
+
+- Testing pure utility logic, validators, or reducers (use `meal-assistant:tdd-vitest`)
+- Testing API route handler error mapping in isolation (use `meal-assistant:tdd-vitest`)
+- Pure styling or layout changes with no behavioral impact
+- Exploratory spikes
+
+## Activation
+
+When this skill triggers:
+
+1. **Identify the feature area.** Map it to (or create) a directory under `cypress/e2e/`:
+   - Page-level mount + render → `cypress/e2e/home/`
+   - Thumbs/skip-reason flow → `cypress/e2e/log/`
+   - Demo-mode smoke → `cypress/e2e/smoke/`
+   - New feature area → create new directory under `cypress/e2e/`
+2. **Default to demo-mode runs.** Real `GITHUB_PAT` / `ANTHROPIC_API_KEY` are not available in CI. Set `DEMO_MODE=1` for the dev server `npm run e2e` boots so the page renders fixture data deterministically. Real-credential runs are an opt-in for local development only.
+3. **Check for existing intercepts and fixtures.** Reuse `cypress/support/*` helpers and `cypress/fixtures/*` data.
+4. **If a plan exists or is being created**, restructure tasks with e2e RED-GREEN-REFACTOR steps inside the relevant unit.
+5. **If no plan exists,** begin the first RED step for the current task.
+
+## Project Test Configuration
+
+```bash
+# Run e2e tests
+npm run e2e              # Boot dev server + run cypress headless
+npm run cypress:open     # Cypress only (assumes dev server running)
+npm run cypress:run      # Cypress only headless (assumes dev server running)
+```
+
+- **Base URL:** `http://localhost:3000` (configured in `cypress.config.ts`)
+- **Spec pattern:** `cypress/e2e/**/*.cy.{ts,tsx,js,jsx}` (Cypress default)
+- **Fixtures:** `cypress/fixtures/` (existing: `recipes.json`, `recipe-single.json`, `empty-recipes.json`)
+- **Support:** `cypress/support/` (existing: `commands.ts`, `e2e.ts` — both currently minimal)
+- **Auth:** None — meal-assistant is single-user, no login flow
+- **Env:** `DEMO_MODE=1` recommended for deterministic E2E. Without it, the page calls real GitHub / Flipp / Anthropic and depends on creds + external availability.
+
+### Directory structure (target)
+
+```
+cypress/
+├── e2e/
+│   ├── smoke/             # Page-level demo-mode smoke (mount, render, click)
+│   ├── home/              # Single-page UI behaviors (regenerate, swap)
+│   └── log/               # Thumbs / skip-reason interactions (when applicable)
+├── support/
+│   ├── e2e.ts             # Global setup
+│   ├── commands.ts        # Custom commands
+│   └── intercepts.ts      # Per-API intercept helpers (added as needed)
+└── fixtures/
+    ├── recipes.json       # Existing
+    ├── recipe-single.json # Existing
+    ├── empty-recipes.json # Existing
+    └── meal-plan.json     # Add as needed
+```
+
+## The Cycle
+
+For each user-visible behavior:
+
+### 1. RED — Write a Failing E2E Test
+
+Write a Cypress test that describes the expected user experience. Run `npm run cypress:run` (or `cypress:open` for visual feedback) and confirm the test fails.
+
+The failure should be meaningful — "element not found" or "expected text not visible" — not a test setup error.
+
+**Test naming — describe user workflows:**
+
+| Bad | Good |
+|---|---|
+| `test home page` | `renders five meal cards from the demo plan` |
+| `test thumbs` | `clicking thumbs-down on a meal card reveals the skip-reason input` |
+| `test regenerate` | `clicking regenerate replaces all five meal cards` |
+
+### 2. GREEN — Build the Feature
+
+Implement the minimum UI and backend logic to make the e2e test pass. This may involve:
+
+- Adding React components or modifying existing ones
+- Wiring API calls via `src/lib/api/client.ts` or new endpoints
+- Adding lib helpers in `src/lib/`
+- Extending the reducer in `src/lib/plan-ui/state.ts`
+
+Run the e2e test and the full vitest suite — both must pass.
+
+### 3. REFACTOR — Clean Up on Green
+
+With all tests passing, improve the code:
+
+- Extract reusable components, hooks, or helpers
+- Consolidate intercept patterns into `cypress/support/intercepts.ts`
+- Improve test readability (extract custom commands, add fixtures)
+
+Run both test suites after each change.
+
+### 4. Repeat
+
+Move to the next user-visible behavior. E2E cycles are naturally larger than unit cycles — each one may take 30-60 minutes. If longer, break the feature into smaller user-visible increments.
+
+## Meal-Assistant-Specific Patterns
+
+### Demo-mode smoke test
+
+```typescript
+// cypress/e2e/smoke/home.cy.ts
+describe("Home page (demo mode)", () => {
+  it("renders five meal cards, deals sidebar, and grocery list", () => {
+    cy.visit("/");
+    cy.contains(/this week's meals/i).should("be.visible");
+    cy.findAllByLabelText(/Meal \d:/).should("have.length", 5);
+    cy.findByLabelText(/this week's deals/i).should("be.visible");
+    cy.findByLabelText(/grocery list/i).should("be.visible");
+  });
+});
+```
+
+### Intercepts with fixtures
+
+```typescript
+// cypress/support/intercepts.ts
+export function interceptHomeApis() {
+  cy.intercept("GET", "/api/recipes", { fixture: "recipes.json" }).as("getRecipes");
+  cy.intercept("GET", "/api/deals", { fixture: "deals.json" }).as("getDeals");
+  cy.intercept("POST", "/api/generate-plan", { fixture: "meal-plan.json" }).as("generatePlan");
+}
+
+// In a spec
+import { interceptHomeApis } from "../../support/intercepts";
+
+beforeEach(() => {
+  interceptHomeApis();
+});
+
+it("waits for the plan to load before showing meal cards", () => {
+  cy.visit("/");
+  cy.wait("@generatePlan");
+  cy.contains("Meal-A").should("be.visible");
+});
+```
+
+### Testing user actions (regenerate, swap, thumbs)
+
+```typescript
+it("clicking regenerate calls /api/generate-plan again and replaces all meals", () => {
+  interceptHomeApis();
+  cy.intercept("POST", "/api/generate-plan", { fixture: "meal-plan-fresh.json" }).as(
+    "regenerate",
+  );
+
+  cy.visit("/");
+  cy.wait("@generatePlan");
+  cy.findByRole("button", { name: /regenerate plan/i }).click();
+  cy.wait("@regenerate");
+  cy.contains("New-0").should("be.visible");
+});
+```
+
+### Testing error states
+
+```typescript
+it("shows the error card with retry when /api/recipes 500s", () => {
+  cy.intercept("GET", "/api/recipes", {
+    statusCode: 500,
+    body: { error: "GITHUB_PAT environment variable is required" },
+  }).as("getRecipes");
+
+  cy.visit("/");
+  cy.contains(/something went wrong/i).should("be.visible");
+  cy.findByRole("button", { name: /try again/i }).should("be.visible");
+});
+```
+
+### Fixture organization
+
+When adding new fixtures:
+
+- Place in `cypress/fixtures/`
+- Use descriptive filenames: `meal-plan.json`, `meal-plan-fresh.json`, `recent-logs.json`
+- Structure mirrors the API response shape (the typed `MealPlan`, `Deal[]`, etc. from `src/lib/*/types.ts`)
+- Keep fixtures minimal — only the fields the test asserts against
+- Reuse demo-mode fixture data (`src/lib/demo/fixtures.ts`) as inspiration; the JSON shape is the same
+
+## Structuring plans for E2E TDD
+
+When TDD is requested alongside a plan, the plan unit defines **what** to build; e2e RED-GREEN-REFACTOR defines **how** to build it.
+
+**Standard plan unit:**
+
+```markdown
+- U6. **Page composition + layout container**
+  Goal: Wire usePlanState and the three components into src/app/page.tsx.
+```
+
+**E2E TDD-augmented (cycles live in commits / task tracker, not the plan body):**
+
+```markdown
+- U6. **Page composition + layout container**
+  - RED (e2e): Home page renders five meal cards from demo plan
+  - GREEN: Wire usePlanState + render 5 MealCard with isSwapping=generating
+  - RED (e2e): Clicking regenerate replaces all five meal titles
+  - GREEN: Add toolbar Button onClick={regenerate}
+  - RED (e2e): Clicking thumbs-down reveals the skip-reason input below the grid
+  - GREEN: Compute anyDownThumbs and conditionally render <Input>
+  - REFACTOR: Extract LoadingState and ErrorState; consolidate intercepts in support/
+  - RED (vitest): Skip-reason input is hidden when no thumbs are down (use meal-assistant:tdd-vitest)
+  - GREEN: Tighten the conditional in page.tsx; update page.test.tsx
+```
+
+E2E TDD often triggers supplementary unit tests via `meal-assistant:tdd-vitest` for edge cases that are expensive to test at the e2e level.
+
+## Discipline rules
+
+1. **Never skip RED.** Run the Cypress test, watch it fail in the browser or headless output.
+2. **Never ship a user-facing feature without an e2e test.** The e2e test IS the acceptance criteria.
+3. **Never refactor on red.** Get to green first.
+4. **Default to `DEMO_MODE=1` for E2E.** The page renders deterministically without GitHub / Flipp / Anthropic creds. Real-cred runs are a manual local exercise, not a CI baseline.
+5. **Keep fixtures minimal and current.** When API shapes change, update fixtures — stale fixtures mask real bugs.
+6. **Prefer `cy.findByRole()` / `cy.findByLabelText()` / `cy.contains()` over fragile CSS selectors.** Use `data-testid` only when no semantic role or label exists (the page uses `data-testid="kid-callout"`, `data-testid="deal-badges"`, `data-testid="skip-reason"` for exactly this purpose).
+7. **Use `cy.intercept()` for API isolation** — e2e tests should not depend on live backend state for deterministic assertions, even when running with real creds available.
+8. **Wait for the request, not for time.** Prefer `cy.wait("@alias")` over `cy.wait(2000)`.
+
+See [anti-patterns.md](./references/anti-patterns.md) for common Cypress TDD mistakes to avoid.

--- a/.claude/skills/meal-assistant/tdd-cypress/references/anti-patterns.md
+++ b/.claude/skills/meal-assistant/tdd-cypress/references/anti-patterns.md
@@ -1,0 +1,128 @@
+# Cypress E2E TDD Anti-Patterns (meal-assistant)
+
+Common mistakes that undermine test-driven development with Cypress in this codebase.
+
+## Testing Implementation Instead of User Experience
+
+**Problem:** Tests assert on internal state, reducer actions, or component prop names instead of what the user sees.
+
+**Correction:** Assert on visible text, element states, and navigation outcomes. If the user can't see it, don't test it in e2e — push it down to a vitest unit test.
+
+## Fragile Selectors
+
+**Problem:** Tests use CSS class selectors or deeply nested DOM paths that break on styling changes.
+
+**Example (bad):**
+
+```typescript
+cy.get(".bg-success.text-success-foreground").click();
+cy.get("section > div > h3:nth-child(2)").should("have.text", "Aldi");
+```
+
+**Correction:** Use ARIA roles, labels, visible text, or `data-testid`.
+
+```typescript
+cy.findByRole("button", { name: /thumbs up/i }).click();
+cy.findByRole("heading", { name: /aldi/i }).should("be.visible");
+```
+
+## Not Using `cy.intercept()` for API Isolation
+
+**Problem:** Tests hit live `/api/recipes`, `/api/deals`, `/api/generate-plan`, `/api/log` and depend on GitHub / Flipp / Anthropic uptime + secrets.
+
+**Correction:** Use `cy.intercept()` with fixtures for deterministic assertions. Use `DEMO_MODE=1` only as a fast happy-path baseline; intercept explicitly when you need a specific shape (an error response, a specific meal title, an empty list).
+
+## Stale Fixtures
+
+**Problem:** API response shapes change but fixtures aren't updated. Tests pass with stale data that no longer matches reality.
+
+**Correction:** When `src/lib/*/types.ts` changes, sweep `cypress/fixtures/` for matching fixtures and update them in the same PR. The TypeScript types are the contract.
+
+## Asserting Before the Page Has Loaded
+
+**Problem:** The page does three parallel fetches + a generate-plan call before rendering meals. Asserting on meal text before the network calls resolve is flaky.
+
+**Example (bad):**
+
+```typescript
+cy.visit("/");
+cy.contains("Meal-A").should("be.visible"); // May fail before generate-plan resolves
+```
+
+**Correction:** Wait for the relevant request before asserting.
+
+```typescript
+cy.intercept("POST", "/api/generate-plan").as("generatePlan");
+cy.visit("/");
+cy.wait("@generatePlan");
+cy.contains("Meal-A").should("be.visible");
+```
+
+Or rely on Cypress's automatic retry-until-found behavior with a generous timeout:
+
+```typescript
+cy.contains("Meal-A", { timeout: 10000 }).should("be.visible");
+```
+
+## Hardcoded Waits
+
+**Problem:** Using `cy.wait(5000)` instead of waiting for specific conditions.
+
+**Correction:** Wait for elements, network requests, or assertions. Cypress automatically retries assertions up to the default 4-second timeout — extend per-assertion if needed.
+
+```typescript
+// Bad
+cy.wait(3000);
+cy.findByText("Generated").should("exist");
+
+// Good
+cy.findByText("Generated", { timeout: 10000 }).should("be.visible");
+```
+
+## Writing E2E Tests for Unit-Level Logic
+
+**Problem:** Using Cypress to test `parseLogFile`, the reducer's `SWAP_OK` action, or `validateInput` edge cases.
+
+**Correction:** Test logic with Vitest (`meal-assistant:tdd-vitest`). Use Cypress only for user-visible workflows that span multiple components and API calls.
+
+## Testing Too Many Workflows in One Spec
+
+**Problem:** A single `it()` block tests page mount, regenerate, swap, thumbs-up, thumbs-down, skip-reason input, and grocery list assertion. When it fails, you don't know which step broke.
+
+**Correction:** One workflow per `it()` block. Use `beforeEach()` for shared setup (intercepts, visit). Each test should be readable in isolation.
+
+## Skipping RED in E2E (AI-Specific)
+
+**Problem:** AI writes the Cypress test and the feature implementation simultaneously. The test was never observed to fail.
+
+**Correction:** Write the Cypress test first. Run `npm run cypress:run`. Watch it fail (element not found, text not visible, request never made). Only then build the feature.
+
+## Not Cleaning Up State Between Tests
+
+**Problem:** Demo-mode is process-level state. If you flip env vars between specs, leakage is possible — but Cypress runs against an already-booted server, so the env is fixed for the whole run.
+
+**Correction:** Choose `DEMO_MODE=1` for the whole e2e run via `npm run e2e` configuration. For tests that need a non-demo response shape, use `cy.intercept()` to override per-test rather than restarting the server.
+
+## Over-Broad Error Suppression
+
+**Problem:** Globally suppressing all uncaught exceptions hides real application errors.
+
+**Correction:** Let application errors fail tests. Suppress only known third-party noise (e.g., ResizeObserver loop warnings). The current `cypress/support/e2e.ts` is minimal — extend deliberately.
+
+## Using `data-testid` When a Role or Label Works
+
+**Problem:** Sprinkling `data-testid` everywhere when ARIA roles, labels, or visible text would do.
+
+**Correction:** Prefer `cy.findByRole()` / `cy.findByLabelText()` / `cy.contains()`. Reserve `data-testid` for cases where no semantic anchor exists or text is dynamic. The page already uses `data-testid="kid-callout"`, `data-testid="deal-badges"`, `data-testid="skip-reason"` for the genuine cases — match that bar.
+
+## Hitting Real GitHub / Anthropic in CI
+
+**Problem:** Cypress run in CI uses the real `GITHUB_PAT` and `ANTHROPIC_API_KEY` — flaky, slow, and burns API credits.
+
+**Correction:** Configure CI to set `DEMO_MODE=1` before booting the dev server, OR intercept all `/api/*` calls in `beforeEach()`. Real-cred runs are local-dev only.
+
+## Co-Locating Cypress Tests with Source
+
+**Problem:** Putting `*.cy.ts` next to `*.tsx` source files. Cypress's spec pattern doesn't pick them up; vitest may try to load them.
+
+**Correction:** Cypress specs live under `cypress/e2e/`. Vitest specs are co-located in `src/`. Don't mix.

--- a/.claude/skills/meal-assistant/tdd-vitest/SKILL.md
+++ b/.claude/skills/meal-assistant/tdd-vitest/SKILL.md
@@ -1,0 +1,312 @@
+---
+name: meal-assistant:tdd-vitest
+description: TDD workflow for unit, integration, and component tests using Vitest in the meal-assistant codebase. Use when implementing features, fixing bugs, or adding test coverage with a test-first approach. Triggers on "TDD", "test-driven", "test first", "write tests first", "red-green-refactor", "vitest TDD", or when the user requests test-driven development for unit, hook, route-handler, or component tests.
+---
+
+# Test-Driven Development with Vitest
+
+Integrate red-green-refactor discipline into implementation using Vitest for unit and component tests in the meal-assistant codebase.
+
+## Philosophy
+
+The test is the first consumer of the API. If it is awkward to test, the design is wrong.
+
+This skill follows the Classical (Chicago) school of TDD: prefer real objects over test doubles, assert on state and outcomes, mock only at system boundaries (`fetch` for GitHub / Flipp / Anthropic, `process.env` for config, `sonner` for non-blocking toasts).
+
+## When to Use
+
+**Apply TDD when:**
+
+- Implementing a new pure utility (parser, validator, serializer, error class)
+- Adding or modifying an API route handler under `src/app/api/*/route.ts`
+- Building a new React component or hook in `src/components/` or `src/lib/plan-ui/`
+- Adding a state-machine action to `src/lib/plan-ui/state.ts`
+- Fixing a bug — reproduce it as a failing test before patching
+- Designing a new lib module (e.g., `src/lib/log/`, `src/lib/recipes/`)
+
+**Skip TDD when:**
+
+- Pure config or boilerplate wiring (`vitest.config.ts`, `next.config.ts`, route file scaffolds with no logic yet)
+- Pure styling and Tailwind class changes with no behavior change
+- Trivial renames or one-line changes
+- Updating fixtures, plan documents, or `CLAUDE.md`
+- Exploratory spikes you intend to delete
+
+## Activation
+
+When this skill triggers:
+
+1. **Detect the context.** Identify whether the code under test is:
+   - A pure utility (parser, validator, type guard) → test directly with concrete inputs and outputs
+   - An API route (`src/app/api/<name>/route.ts`) → call `GET`/`POST` with a real `Request`, assert on status / headers / body
+   - A React component → use `@testing-library/react` with `render()`, `screen`, `fireEvent`
+   - A custom hook → use `renderHook()` from `@testing-library/react`
+   - A Next.js GitHub/Flipp/Anthropic-touching helper → mock `globalThis.fetch` with `vi.stubGlobal("fetch", ...)`
+   - A reducer (e.g., `planReducer`) → call directly with concrete `PlanState` and `PlanAction` values
+2. **If a plan exists or is being created**, follow the unit boundaries the plan defines and add red-green-refactor cycles inside each unit.
+3. **If no plan exists,** begin the first RED step for the current task.
+
+## Project Test Configuration
+
+```bash
+# Run tests
+npm test                 # vitest run (one-shot)
+npm run test:watch       # vitest (watch mode)
+```
+
+- **Default environment:** `node` (configured in `vitest.config.ts`)
+- **Component / hook tests:** opt into jsdom **per file** with `// @vitest-environment jsdom` as the very first line. Do not flip the global default — pure-logic suites should stay on the faster Node environment.
+- **Globals:** Enabled — `describe`, `it`, `expect` available without imports
+- **Setup:** `src/test/setup.ts` (currently just `@testing-library/jest-dom/vitest` matchers)
+- **Path alias:** `@/*` → `./src/*`
+
+### Test file locations
+
+Tests are **co-located** with the source they exercise. There is no `__tests__` directory.
+
+| Source | Test |
+|---|---|
+| `src/lib/log/parse.ts` | `src/lib/log/parse.test.ts` |
+| `src/lib/api/client.ts` | `src/lib/api/client.test.ts` |
+| `src/components/meal-card.tsx` | `src/components/meal-card.test.tsx` |
+| `src/lib/plan-ui/state.ts` | `src/lib/plan-ui/state.test.ts` |
+| `src/lib/plan-ui/use-plan-state.ts` | `src/lib/plan-ui/use-plan-state.test.tsx` (jsdom) |
+| `src/app/api/log/route.ts` | `src/app/api/log/route.test.ts` |
+| `src/app/page.tsx` | `src/app/page.test.tsx` (jsdom) |
+
+## The Cycle
+
+For each behavioral increment:
+
+### 1. RED — Write a Failing Test
+
+Write a test that describes the expected behavior. Run `npm test -- <path>` and confirm the new test fails.
+
+If the test passes immediately, investigate why. A test that was never red is not trustworthy.
+
+**Test naming — describe behavior, not methods:**
+
+| Bad | Good |
+|---|---|
+| `test_parseLogFile` | `parses a 2-block file in document order` |
+| `test_handleClick` | `clicking thumbs-up dispatches setThumb with up` |
+| `test_validate` | `throws InvalidLogRequestError when week is not YYYY-MM-DD` |
+
+### 2. GREEN — Make It Pass
+
+Write the minimum code to make the failing test pass. No cleverness. No optimization.
+
+Run the full test suite — confirm all tests pass, not just the new one.
+
+### 3. REFACTOR — Clean Up on Green
+
+With all tests passing, improve the code:
+
+- Remove duplication
+- Improve naming
+- Extract helpers that have earned their existence
+- Simplify conditional logic
+
+Run the test suite after each change. Never refactor on red.
+
+### 4. Repeat
+
+Move to the next behavioral increment. Each cycle should take minutes, not hours.
+
+## Meal-Assistant-Specific Patterns
+
+### Pure utility / parser tests
+
+```typescript
+import { describe, expect, it } from "vitest";
+import { parseLogFile, LogParseError } from "./parse";
+
+describe("parseLogFile", () => {
+  it("parses a 2-block file in document order", () => {
+    const got = parseLogFile(SOURCE, "2026-04.md");
+    expect(got).toHaveLength(2);
+    expect(got[0]).toEqual({ week: "2026-04-13", cooked: ["tacos"], skipped: [] });
+  });
+
+  it("throws LogParseError when week is malformed", () => {
+    expect(() => parseLogFile("---\nweek: bad\ncooked: []\nskipped: []\n---\n", "x.md"))
+      .toThrow(LogParseError);
+  });
+});
+```
+
+### API route handler tests
+
+Routes export `GET` and/or `POST` that take a real `Request`. Pass a `Request` directly; assert on the `Response`.
+
+```typescript
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { POST } from "./route";
+
+const upsertMock = vi.fn();
+vi.mock("@/lib/log/github", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/log/github")>("@/lib/log/github");
+  return { ...actual, upsertWeekEntry: (entry: unknown) => upsertMock(entry) };
+});
+
+beforeEach(() => {
+  upsertMock.mockReset();
+  delete process.env.DEMO_MODE;
+});
+
+it("returns 200 and calls upsertWeekEntry on a valid body", async () => {
+  upsertMock.mockResolvedValue(undefined);
+  const req = new Request("http://localhost/api/log", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ week: "2026-04-20", cooked: ["tacos"], skipped: [] }),
+  });
+  const res = await POST(req);
+  expect(res.status).toBe(200);
+  expect(upsertMock).toHaveBeenCalledTimes(1);
+});
+```
+
+### `fetch`-mocking for GitHub / Flipp / Anthropic
+
+```typescript
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+beforeEach(() => {
+  process.env.GITHUB_PAT = "ghp_test";
+  process.env.RECIPES_REPO = "owner/repo";
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  delete process.env.GITHUB_PAT;
+  delete process.env.RECIPES_REPO;
+});
+
+it("returns null on 404 from GitHub contents API", async () => {
+  vi.stubGlobal("fetch", vi.fn(async () => new Response("Not Found", { status: 404 })));
+  expect(await getLogFile("2026-04")).toBeNull();
+});
+```
+
+### Component tests (jsdom)
+
+```typescript
+// @vitest-environment jsdom
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { MealCard } from "./meal-card";
+
+describe("MealCard", () => {
+  it("calls onSwap with the index when the swap button is clicked", () => {
+    const onSwap = vi.fn();
+    render(
+      <MealCard
+        meal={{ title: "Tacos", kidVersion: null, dealMatches: [] }}
+        index={3}
+        isSwapping={false}
+        thumb={null}
+        onSwap={onSwap}
+        onThumbsUp={vi.fn()}
+        onThumbsDown={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /swap meal 4/i }));
+    expect(onSwap).toHaveBeenCalledWith(3);
+  });
+});
+```
+
+### Hook tests (jsdom + renderHook)
+
+```typescript
+// @vitest-environment jsdom
+import { renderHook, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+const fetchRecipesMock = vi.fn();
+vi.mock("@/lib/api/client", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api/client")>("@/lib/api/client");
+  return { ...actual, fetchRecipes: () => fetchRecipesMock() };
+});
+
+vi.mock("sonner", () => ({ toast: { error: vi.fn(), warning: vi.fn() } }));
+
+import { usePlanState } from "./use-plan-state";
+
+it("transitions to ready after the parallel fetch resolves", async () => {
+  fetchRecipesMock.mockResolvedValue([]);
+  const { result } = renderHook(() => usePlanState());
+  await waitFor(() => expect(result.current.state.status).toBe("ready"));
+});
+```
+
+### Reducer tests (pure)
+
+```typescript
+import { describe, expect, it } from "vitest";
+import { initialState, planReducer } from "./state";
+
+describe("planReducer", () => {
+  it("INIT_OK transitions loading -> ready", () => {
+    const next = planReducer(initialState, {
+      type: "INIT_OK",
+      recipes: [],
+      deals: [],
+      recentLogs: [],
+      plan: { meals: [], groceryList: [] },
+      currentWeek: "2026-04-20",
+    });
+    expect(next.status).toBe("ready");
+  });
+});
+```
+
+## Mocking guidelines (Classical TDD)
+
+- **Mock at boundaries:** `fetch` for GitHub/Flipp/Anthropic (use `vi.stubGlobal("fetch", ...)`), `sonner.toast` for non-blocking UX surface, `@/lib/api/client` exports when testing the page or hook end-to-end
+- **Use real objects:** the reducer, parsers, validators, type guards, error classes, and your own React components composed with each other
+- **Use `vi.fn()`** for callbacks and event handlers passed as props
+- **Use `vi.spyOn()`** for observing calls without replacing implementation
+- **Reset between tests:** `beforeEach(() => { vi.clearAllMocks(); })` or `afterEach(() => { vi.restoreAllMocks(); })`
+- **`process.env`:** snapshot the original, mutate per-test, restore in `afterEach`. Do not use `vi.stubEnv` for `DEMO_MODE` / `GITHUB_PAT` etc. — direct mutation is the existing convention in this repo (see `src/lib/log/github.test.ts`)
+- **Demo-mode tests:** set `process.env.DEMO_MODE = "1"` before importing the route, and assert that the upstream mock (e.g., `fetch`) was never called
+
+## Restructuring plans for TDD
+
+When TDD is requested alongside a plan, break each implementation unit into behavioral increments. Plan units already define **what**; TDD defines **how**.
+
+**Standard implementation unit:**
+
+```markdown
+- U2. **GitHub log read/write + 409 retry**
+  Goal: GET/PUT contents API + upsertWeekEntry orchestrator with single 409 retry.
+  Files: src/lib/log/github.ts, src/lib/log/github.test.ts
+```
+
+**TDD-augmented unit (carry inside the same plan unit, not a new one):**
+
+```markdown
+- U2. **GitHub log read/write + 409 retry**
+  - RED: getLogFile returns null on 404
+  - GREEN: implement getLogFile with 404 -> null, otherwise base64-decode + return { content, sha }
+  - RED: getLogFile throws GitHubAuthError on 401/403
+  - GREEN: branch on status before parsing JSON
+  - RED: upsertWeekEntry retries once on 409 then succeeds (4 fetches)
+  - GREEN: wrap orchestrator in try/catch with one retry
+  - REFACTOR: extract requireEnv + buildAuthHeaders to share with recipes/github.ts
+```
+
+The plan stays a decision artifact — RED/GREEN bullets live in commit messages, the task tracker, or as ephemeral working notes. Don't expand the plan body with them.
+
+## Discipline rules
+
+1. **Never skip RED.** Run the test, see it fail, read the failure message.
+2. **Never commit a behavioral change without a test.** Config and boilerplate are exempt.
+3. **Never refactor on red.** Get to green first.
+4. **Keep cycles small.** If RED-GREEN takes more than 15-20 minutes, split the increment.
+5. **Test behavior, not implementation.** Assert on what the user sees, what the route returns, or what the caller receives — not on private internals.
+6. **Run the full suite before committing each unit.** Catch unintended breakage early.
+7. **Co-locate the test file.** Same directory, `.test.ts` or `.test.tsx` suffix matching the source.
+
+See [anti-patterns.md](./references/anti-patterns.md) for common mistakes to avoid.

--- a/.claude/skills/meal-assistant/tdd-vitest/references/anti-patterns.md
+++ b/.claude/skills/meal-assistant/tdd-vitest/references/anti-patterns.md
@@ -1,0 +1,164 @@
+# Vitest TDD Anti-Patterns (meal-assistant)
+
+Common mistakes that undermine test-driven development with Vitest in this codebase.
+
+## Testing Implementation Instead of Behavior
+
+**Problem:** Tests coupled to private helpers, exact regex variants, or specific YAML formatting that don't matter to callers. Refactoring breaks tests even when behavior is unchanged.
+
+**Example (bad):**
+
+```typescript
+// Tests private formatYamlValue helper through the parser's internals
+expect(serializeLogFile([entry])).toMatch(/cooked: \[tacos, salmon\]/);
+```
+
+**Correction:** Round-trip the actual contract.
+
+```typescript
+expect(parseLogFile(serializeLogFile([entry]), "x.md")).toEqual([entry]);
+```
+
+## Forgetting `// @vitest-environment jsdom`
+
+**Problem:** Component or hook test imports `@testing-library/react`, fails with `document is not defined` because the global Vitest environment is `node`.
+
+**Correction:** Add `// @vitest-environment jsdom` as the very first line of any file that uses `render` or `renderHook`. Do not flip the global default — pure-logic suites should stay on Node.
+
+## Mocking Everything
+
+**Problem:** Every dependency is mocked. Tests pass but the system doesn't actually work. Common when testing the page or hook layer.
+
+**Example (bad):**
+
+```typescript
+vi.mock("@/lib/api/client");
+vi.mock("@/lib/plan-ui/state");
+vi.mock("@/components/meal-card");
+// Now testing nothing real
+```
+
+**Correction (Classical approach):** Mock at boundaries — `fetch` for GitHub / Flipp / Anthropic, `@/lib/api/client` only when you want to drive the page from above. The reducer, components, and parsers stay real.
+
+## Skipping the Refactor Step
+
+**Problem:** RED-GREEN without REFACTOR. Code works but accumulates duplication and tangled logic.
+
+**Correction:** After each GREEN, ask: duplication? naming? emerging abstraction? Even "no changes needed" is a valid refactor step.
+
+## Testing Framework or Library Code
+
+**Problem:** Testing that React renders a component, that Next.js parses a `Request`, that `gray-matter` returns frontmatter, or that Vitest matchers function.
+
+**Correction:** Test your logic — business rules, validation, conditional rendering, error mapping. Trust the framework.
+
+## Gold-Plating Assertions
+
+**Problem:** Over-specified assertions that check every prop, every CSS class, every attribute.
+
+**Example (bad):**
+
+```typescript
+expect(screen.getByRole("button")).toHaveAttribute(
+  "class",
+  "px-2.5 h-7 gap-1 rounded-... bg-secondary text-secondary-foreground ...",
+);
+```
+
+**Correction:** Assert on what matters to behavior.
+
+```typescript
+expect(screen.getByRole("button", { name: /swap meal 1/i })).toBeEnabled();
+```
+
+## Snapshot Overuse
+
+**Problem:** Using `toMatchSnapshot()` as a substitute for behavioral assertions. Snapshots test structure, not behavior, and break on every CSS or copy change.
+
+**Correction:** Use snapshots sparingly. For UI, assert on specific elements and visible text. For prompts (`src/lib/plan/prompt.ts`), prefer string-contains checks for the load-bearing instruction lines, not full-prompt snapshots.
+
+## Not Cleaning Up Mocks
+
+**Problem:** `vi.fn()` or `vi.stubGlobal("fetch", ...)` state leaks between tests, causing intermittent failures.
+
+**Correction:**
+
+```typescript
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+```
+
+For `process.env`, snapshot the original in `beforeEach` and restore in `afterEach` — see `src/lib/log/github.test.ts` for the pattern.
+
+## Over-Implementing on GREEN (AI-Specific)
+
+**Problem:** AI writes the complete, optimized solution in the GREEN step instead of the minimum code to pass.
+
+**Correction:** In GREEN, write only what the failing test demands. The next test forces generalization. If you find yourself writing branches not yet exercised, delete them and write the next RED first.
+
+## Mirror Tests (AI-Specific)
+
+**Problem:** Tests re-implement the production code formula instead of using concrete values.
+
+**Example (bad):**
+
+```typescript
+// Production: skipReason set when non-empty
+expect(parseLogFile(src, "x.md")[0].skipReason).toBe(reason !== "" ? reason : undefined);
+```
+
+**Correction:** Use concrete values.
+
+```typescript
+expect(parseLogFile(srcWithEmptyReason, "x.md")[0].skipReason).toBeUndefined();
+expect(parseLogFile(srcWithReason, "x.md")[0].skipReason).toBe("kid was sick");
+```
+
+## Skipping RED Verification (AI-Specific)
+
+**Problem:** AI writes the test and the implementation in the same step without verifying the test fails first.
+
+**Correction:** Always run `npm test -- <path>` before writing implementation. See the failure. Read the message. Only then write GREEN.
+
+## Mocking `process.env` Wrong
+
+**Problem:** Tests that don't restore `DEMO_MODE` / `GITHUB_PAT` between tests cause leakage between unrelated suites.
+
+**Correction:** Snapshot in `beforeEach`, restore in `afterEach`:
+
+```typescript
+const originalDemo = process.env.DEMO_MODE;
+beforeEach(() => { delete process.env.DEMO_MODE; });
+afterEach(() => {
+  if (originalDemo === undefined) delete process.env.DEMO_MODE;
+  else process.env.DEMO_MODE = originalDemo;
+});
+```
+
+Or simply `delete process.env.DEMO_MODE` in `beforeEach` since the default expected state is unset.
+
+## Calling Routes via `fetch("/api/...")` Inside Tests
+
+**Problem:** Trying to test a Next.js route by hitting a localhost URL — the dev server isn't running in `vitest`.
+
+**Correction:** Import the handler directly and call it with a `Request`:
+
+```typescript
+import { POST } from "@/app/api/log/route";
+const res = await POST(new Request("http://localhost/api/log", { method: "POST", body: "{...}" }));
+expect(res.status).toBe(200);
+```
+
+## Asserting on Headers Using `Object.fromEntries`
+
+**Problem:** `Headers` instances iterate but `Object.fromEntries` may merge multi-value headers in surprising ways.
+
+**Correction:** Use `res.headers.get("X-Header")`. Direct, deterministic, matches how the route emits them.
+
+## Re-Reading Files in Tests
+
+**Problem:** Tests that read fixtures with `fs.readFileSync` add filesystem coupling and slow test startup.
+
+**Correction:** Define fixture data inline as TypeScript constants (see `src/lib/log/github.test.ts` `SAMPLE_FILE`). Filesystem reads are fine for `cypress/fixtures/*` (consumed by Cypress at runtime) but not for vitest unit tests.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,29 @@ Do not reintroduce Supabase, SQLite, `better-sqlite3`, `@google/genai`, or the w
 - `npm run cypress:open` / `npm run cypress:run` — Cypress e2e (interactive / headless)
 - `npm run e2e` — Boot dev server + run Cypress headless
 
+## Test-Driven Development
+
+**All `feat:` and `fix:` work MUST follow TDD red-green-refactor discipline.** This applies to all implementation — whether initiated by `/ce-work`, `/ce-plan`, subagents, or direct coding.
+
+- **Unit / component / route-handler tests:** Follow `meal-assistant:tdd-vitest` — write a failing Vitest test before writing implementation code, make it pass with the minimum code, then refactor.
+- **End-to-end tests:** Follow `meal-assistant:tdd-cypress` — write a failing Cypress test that defines the user-visible acceptance criteria before building the feature.
+- **Bug fixes:** Reproduce the bug as a failing test first, at whichever level it manifests, then fix it.
+
+Plans created by `/ce-plan` do NOT need to explicitly list RED/GREEN/REFACTOR steps — the TDD cycle is implicit in all implementation work. The plan defines *what* to build; TDD defines *how* to build it. Cycles live in commits or the task tracker, not the plan body.
+
+**When implementing any plan unit or task:**
+
+1. Write a failing test that describes the expected behavior
+2. Run the relevant suite (`npm test -- <path>` or `npm run cypress:run`) and confirm it fails for the right reason
+3. Write the minimum implementation to make it pass
+4. Run the full suite to confirm nothing else broke
+5. Refactor on green; never refactor on red
+6. Commit when the unit is complete (test + implementation in the same logical commit, or test commit immediately followed by green commit — your call)
+
+**Skip TDD only for:** configuration changes, boilerplate wiring, pure styling / Tailwind class changes, trivial renames, doc / plan / fixture updates, and exploratory spikes.
+
+The skill files at `.claude/skills/meal-assistant/tdd-vitest/SKILL.md` and `.claude/skills/meal-assistant/tdd-cypress/SKILL.md` are the source of truth — read them before starting feature or fix work.
+
 ## Architecture
 
 - **Framework:** Next.js 15 with App Router, React 19, TypeScript (strict mode)


### PR DESCRIPTION
## Summary

Adds two Claude Code skills, plus a CLAUDE.md section that mandates red-green-refactor for `feat:` and `fix:` work.

| File | Purpose |
|---|---|
| `.claude/skills/meal-assistant/tdd-vitest/SKILL.md` | Classical TDD for unit / component / route-handler / hook tests |
| `.claude/skills/meal-assistant/tdd-vitest/references/anti-patterns.md` | Common mistakes to avoid |
| `.claude/skills/meal-assistant/tdd-cypress/SKILL.md` | E2E TDD with `DEMO_MODE=1` as the deterministic default + `cy.intercept()` patterns |
| `.claude/skills/meal-assistant/tdd-cypress/references/anti-patterns.md` | E2E-specific pitfalls |
| `CLAUDE.md` | New "Test-Driven Development" section after Commands, before Architecture |

## Adaptations from relay

- No Redux / Lambda / Cognito — examples are reducers, route handlers, hooks, components
- Co-located `*.test.ts` next to source (relay uses `__test__/`)
- `// @vitest-environment jsdom` per-file (relay uses happy-dom global)
- `DEMO_MODE=1` recommended for E2E (single-tenant, no auth)

## Skill triggers

- `meal-assistant:tdd-vitest` — "TDD", "test-driven", "test first", "red-green-refactor", "vitest TDD", or any request for test-driven development on unit / hook / route-handler / component tests
- `meal-assistant:tdd-cypress` — "e2e TDD", "cypress TDD", "test-driven e2e", "e2e test first", or test-driven development for browser-level workflows

## Test plan

- [ ] Open a fresh Claude Code session in this repo, ask Claude to "implement X with TDD" — verify it loads the right skill and writes tests first
- [ ] Verify both skill `description` fields parse cleanly (no YAML frontmatter errors)
- [ ] Verify CLAUDE.md renders the new section correctly on GitHub
- [ ] Independent of #76 and #77 — no source file conflicts; this PR can merge in any order

## Related

- Independent of #76 (single-page UI) and #77 (meal log API)