### PR TITLE
feat(ui): tonight hero, day labels, slimmer meal cards

### DIFF
--- a/src/components/email-button.tsx
+++ b/src/components/email-button.tsx
@@ -40,7 +40,6 @@ export function EmailButton({ plan, disabled }: EmailButtonProps) {
 
   return (
     <Button
-      variant="outline"
       onClick={handleClick}
       disabled={disabled || sending}
       aria-label="Email me this"

--- a/src/components/home-page.tsx
+++ b/src/components/home-page.tsx
@@ -16,6 +16,14 @@ export interface HomePageProps {
   emailEnabled: boolean;
 }
 
+const DAY_LABELS = ["Mon", "Tue", "Wed", "Thu", "Fri"] as const;
+
+function todaySlot(now: Date = new Date()): number | null {
+  const dow = now.getDay(); // 0 Sun .. 6 Sat
+  if (dow >= 1 && dow <= 5) return dow - 1;
+  return null;
+}
+
 function LoadingState() {
   return (
     <div className="grid gap-6 md:grid-cols-12">
@@ -71,6 +79,7 @@ export function HomePage({ emailEnabled }: HomePageProps) {
 
   const { deals, plan, generating, thumbs, skipReason } = state;
   const anyDownThumbs = thumbs.some((t) => t === "down");
+  const tonightIndex = todaySlot();
 
   return (
     <div className="grid gap-6 md:grid-cols-12">
@@ -82,9 +91,9 @@ export function HomePage({ emailEnabled }: HomePageProps) {
         <div className="flex flex-wrap items-center justify-between gap-3">
           <h1 className="text-2xl font-semibold">This week&apos;s meals</h1>
           <div className="flex items-center gap-2">
-            {emailEnabled && <EmailButton plan={plan} disabled={generating} />}
             <Button
-              variant="outline"
+              variant="ghost"
+              size="sm"
               onClick={regenerate}
               disabled={generating}
               aria-label="Regenerate plan"
@@ -92,6 +101,7 @@ export function HomePage({ emailEnabled }: HomePageProps) {
               <RefreshCw className={generating ? "animate-spin" : undefined} />
               {generating ? "Generating…" : "Regenerate plan"}
             </Button>
+            {emailEnabled && <EmailButton plan={plan} disabled={generating} />}
           </div>
         </div>
 
@@ -103,6 +113,8 @@ export function HomePage({ emailEnabled }: HomePageProps) {
               index={index}
               isSwapping={generating}
               thumb={thumbs[index] ?? null}
+              dayLabel={DAY_LABELS[index]}
+              isTonight={index === tonightIndex}
               onSwap={swap}
               onThumbsUp={(i) => setThumb(i, "up")}
               onThumbsDown={(i) => setThumb(i, "down")}

--- a/src/components/meal-card.test.tsx
+++ b/src/components/meal-card.test.tsx
@@ -33,26 +33,16 @@ function renderCard(props: Partial<React.ComponentProps<typeof MealCard>> = {}) 
 }
 
 describe("MealCard", () => {
-  it("renders title, kid version, and a deal badge per dealMatches entry", () => {
+  it("renders title and kid version", () => {
     renderCard({
       meal: meal({
         title: "Tacos",
         kidVersion: "plain chicken, no seasoning",
-        dealMatches: [
-          { item: "chicken thighs", salePrice: "$1.99/lb", store: "safeway" },
-          { item: "tortillas", salePrice: "$2.49", store: "aldi" },
-        ],
       }),
     });
 
     expect(screen.getByText("Tacos")).toBeInTheDocument();
     expect(screen.getByText(/plain chicken, no seasoning/)).toBeInTheDocument();
-    expect(
-      screen.getByText(/chicken thighs.*\$1\.99\/lb.*safeway/),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText(/tortillas.*\$2\.49.*aldi/),
-    ).toBeInTheDocument();
   });
 
   it("does not render kid callout when kidVersion is null", () => {
@@ -60,9 +50,31 @@ describe("MealCard", () => {
     expect(screen.queryByTestId("kid-callout")).toBeNull();
   });
 
-  it("does not render deal badges row when dealMatches is empty", () => {
-    renderCard({ meal: meal({ dealMatches: [] }) });
+  it("never renders per-card deal badges (info lives on the grocery list now)", () => {
+    renderCard({
+      meal: meal({
+        dealMatches: [
+          { item: "chicken thighs", salePrice: "$1.99/lb", store: "safeway" },
+        ],
+      }),
+    });
     expect(screen.queryByTestId("deal-badges")).toBeNull();
+    expect(screen.queryByText(/safeway/i)).toBeNull();
+  });
+
+  it("renders the day label when provided", () => {
+    renderCard({ dayLabel: "Wed" });
+    expect(screen.getByTestId("day-label")).toHaveTextContent("Wed");
+  });
+
+  it("marks the card as tonight when isTonight is true", () => {
+    renderCard({ dayLabel: "Mon", isTonight: true });
+    expect(screen.getByTestId("tonight-marker")).toBeInTheDocument();
+  });
+
+  it("does not render a tonight marker when isTonight is false or absent", () => {
+    renderCard({ dayLabel: "Tue", isTonight: false });
+    expect(screen.queryByTestId("tonight-marker")).toBeNull();
   });
 
   it("calls onSwap with the right index on swap click", () => {

--- a/src/components/meal-card.tsx
+++ b/src/components/meal-card.tsx
@@ -3,7 +3,6 @@
 import { RefreshCw, ThumbsDown, ThumbsUp } from "lucide-react";
 import type { MealPlanMeal } from "@/lib/plan/types";
 import type { Thumb } from "@/lib/plan-ui/state";
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { cn } from "@/lib/utils";
@@ -13,6 +12,8 @@ export interface MealCardProps {
   index: number;
   isSwapping: boolean;
   thumb: Thumb;
+  dayLabel?: string;
+  isTonight?: boolean;
   onSwap: (index: number) => void;
   onThumbsUp: (index: number) => void;
   onThumbsDown: (index: number) => void;
@@ -23,14 +24,37 @@ export function MealCard({
   index,
   isSwapping,
   thumb,
+  dayLabel,
+  isTonight = false,
   onSwap,
   onThumbsUp,
   onThumbsDown,
 }: MealCardProps) {
   return (
-    <Card aria-label={`Meal ${index + 1}: ${meal.title}`}>
-      <CardHeader>
-        <CardTitle className="text-lg">{meal.title}</CardTitle>
+    <Card
+      aria-label={`Meal ${index + 1}: ${meal.title}`}
+      className={cn(
+        isTonight &&
+          "ring-2 ring-primary/60 shadow-md sm:col-span-2 xl:col-span-2",
+      )}
+    >
+      <CardHeader className="gap-1">
+        {(dayLabel || isTonight) && (
+          <div className="flex items-center gap-2 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            {isTonight && (
+              <span
+                data-testid="tonight-marker"
+                className="rounded-full bg-primary px-2 py-0.5 text-[0.6875rem] font-semibold text-primary-foreground"
+              >
+                Tonight
+              </span>
+            )}
+            {dayLabel && <span data-testid="day-label">{dayLabel}</span>}
+          </div>
+        )}
+        <CardTitle className={cn(isTonight ? "text-xl" : "text-lg")}>
+          {meal.title}
+        </CardTitle>
       </CardHeader>
 
       <CardContent className="flex flex-col gap-3">
@@ -41,20 +65,6 @@ export function MealCard({
           >
             <span aria-hidden="true">🧒 </span>
             <span>{meal.kidVersion}</span>
-          </div>
-        )}
-
-        {meal.dealMatches.length > 0 && (
-          <div
-            className="flex flex-wrap gap-1.5"
-            data-testid="deal-badges"
-          >
-            {meal.dealMatches.map((dm, i) => (
-              <Badge key={`${dm.item}-${i}`} variant="secondary">
-                <span aria-hidden="true">🏷 </span>
-                {dm.item} {dm.salePrice} @ {dm.store}
-              </Badge>
-            ))}
           </div>
         )}
 


### PR DESCRIPTION
## Why

The plan page was organized around the *generation event* — five undifferentiated meal cards, equal-weight Email/Regenerate buttons, and per-card deal badges that duplicated the grocery list. A family member opening this at 5pm needs to know **what we're cooking tonight**, not relitigate the week.

## Changes

- **Day labels (Mon–Fri).** Each card shows its weekday in the header.
- **Tonight hero.** When today is Mon–Fri, that card gets a `Tonight` pill, a larger title, a primary-tinted ring + shadow, and spans 2 columns at `sm`/`xl`. Weekends: no card is elevated.
- **Slimmer cards.** Per-card deal-match badges are gone. Store + sale price still live on the grocery list (which is where you act on them). Cards now lead with dish name and the kid-version chip — the actually-distinctive content.
- **Demoted Regenerate, promoted Email.** `Email me this` is now the primary CTA (default variant, rightmost). `Regenerate plan` is a ghost button — re-rolling shouldn't sit at equal weight with the done/send action.

No backend changes; pure presentation + one tiny `DAY_LABELS` constant. `dayLabel` and `isTonight` are optional `MealCard` props so test fixtures don't have to know about them.

## Test plan

- [x] `npm test` — 433/433 passing (added 3 new MealCard tests for day label + tonight marker; rewrote the deal-badges test to assert they no longer render)
- [x] `npm run lint` — clean
- [ ] Manual: load the page Mon–Fri, confirm today's card is the visual hero
- [ ] Manual: load the page Sat/Sun, confirm no card is elevated
- [ ] Manual: with `RESEND_API_KEY` set, confirm Email is the primary button and Regenerate is a quieter ghost