### PR TITLE
feat(design): adopt Editorial design tokens (foundation)

### DIFF
--- a/design/README.md
+++ b/design/README.md
@@ -1,0 +1,38 @@
+# Meal Assistant — Handoff Package
+
+This folder is everything Claude Code needs to take the design from prototype to Next.js implementation.
+
+## Contents
+
+| File                | Purpose                                                                 |
+|---------------------|-------------------------------------------------------------------------|
+| `spec.md`           | Screen-by-screen description, component contracts, behaviors, data shapes. Start here. |
+| `design-system.md`  | Portable design language |
+| `tokens.json`       | Machine-readable design tokens (color, type, spacing, motion, radii).   |
+| `data-model.ts`     | Suggested TypeScript types for Meal, FamilyMember, DaySlot, etc.        |
+
+## Source prototype
+
+The interactive reference is `Meal Assistant.html` at the project root. Open it for the source of truth on layout and interaction. The visual contract is the tokens — don't pixel-match against the prototype, match against `tokens.json`.
+
+## Suggested implementation order
+
+1. Set up tokens (`tokens.json` → CSS custom properties + Tailwind theme extension if you use it).
+2. Lift portable components from `design-system.md` §6 into `components/ui/`.
+3. Build the read-only Week screen end to end (hardest layout, gets you most of the type/motion system).
+4. Library + Cadence + Grocery — same primitives, different shapes.
+5. Settings (Family + Calendar).
+6. Add Meal flow (last, it's a modal).
+
+## Stack notes
+
+- Next.js app router.
+- Use server components for the read paths (`/`, `/library`, `/cadence`, `/grocery`, `/settings/*`).
+- Server actions for swap, react, regenerate, sync-now.
+- Add Meal as a parallel/intercepted route at `/library/new` so the library stays behind it.
+
+## Open product questions to flag back to design
+
+- Recipe instruction view — out of scope here, will be a separate pass.
+- Multi-week planning — same.
+- Skylight integration: prototype assumes OAuth-style connect. Real path is likely iCal feed paste or shared Google calendar. UI is provider-agnostic; only `SyncState.provider` needs to flex.

--- a/design/data-model.ts
+++ b/design/data-model.ts
@@ -1,0 +1,150 @@
+// Meal Assistant — TypeScript data model
+// Drop into your Next.js project at e.g. lib/types.ts
+
+export type Protein = 'fish' | 'chicken' | 'beef' | 'pork' | 'turkey' | 'shrimp' | 'veg';
+
+export type Cuisine =
+  | 'simple'
+  | 'italian'
+  | 'tex-mex'
+  | 'asian'
+  | 'mediterranean'
+  | 'american';
+
+export type ThemeTag = 'taco-tuesday' | 'fish-friday';
+
+export type DayKey = 'MON' | 'TUE' | 'WED' | 'THU' | 'FRI' | 'SAT' | 'SUN';
+
+export interface Ingredient {
+  qty: string;            // human-readable, e.g. "1.5 lb"
+  name: string;
+  store?: string;         // 'Aldi' | 'Safeway' | 'Costco' | string — free-form
+}
+
+export interface Meal {
+  id: string;
+  name: string;
+  protein: Protein;
+  cuisine: Cuisine;
+  themes: ThemeTag[];
+  prep: number;           // minutes
+  source?: string;        // URL or human label ("Smitten Kitchen", "Mom")
+  notes?: string;
+  ingredients?: Ingredient[];
+  photoUrl?: string;
+
+  // Server-computed (read-only client side)
+  lastMade?: string;      // ISO date
+  timesThisMonth?: number;
+  rating?: number;        // 0..5, derived from reactions
+}
+
+export type FamilyRole = 'adult' | 'kid';
+
+export interface FamilyMod {
+  /** Case-insensitive substring matched against `meal.name` */
+  match: string;
+  /** What to do — printed verbatim on the meal card */
+  text: string;
+}
+
+export interface FamilyMember {
+  id: string;
+  name: string;
+  role: FamilyRole;
+  age?: number;
+  avatar: string;         // single character or emoji-free initials
+  likes: string[];        // free-form tags: 'fish', 'cheese', 'spicy'
+  dislikes: string[];
+  allergens: string[];    // 'shellfish', 'tree-nuts', etc.
+  mods: FamilyMod[];
+}
+
+export type EventKind = 'soccer' | 'dinner-out' | 'work' | 'travel' | 'other';
+export type EventImpact = 'skip' | 'quick-meal' | 'shift-time' | 'none';
+
+export interface CalendarEvent {
+  kind: EventKind;
+  label: string;
+  impact: EventImpact;
+  startsAt?: string;      // ISO timestamp
+  source?: 'skylight' | 'google' | 'apple' | 'ical';
+}
+
+export interface DaySlot {
+  day: DayKey;
+  date: string;           // 'Apr 27'
+  isoDate: string;        // '2026-04-27'
+  mealId: string | null;
+  theme: string | null;   // display label, e.g. 'Taco Tuesday'
+  event: CalendarEvent | null;
+}
+
+export interface WeekPlan {
+  id: string;
+  weekStartIso: string;   // Monday
+  slots: DaySlot[];       // 7 entries
+  generatedAt: string;
+  /** mealIds the user explicitly liked this week — preserved on regeneration */
+  pinned: string[];
+}
+
+export type SyncProvider = 'skylight' | 'google' | 'apple' | 'ical';
+
+export interface SyncState {
+  connected: boolean;
+  provider: SyncProvider;
+  account?: string;
+  lastSync?: string;      // ISO timestamp
+  calendars: string[];
+}
+
+export interface CadenceRule {
+  id: string;
+  label: string;
+  detail: string;
+  enabled: boolean;
+  /** Engine-specific config; shape per rule type */
+  config?: Record<string, unknown>;
+}
+
+export interface MealReaction {
+  mealId: string;
+  userId: string;
+  direction: 'up' | 'down' | null;
+  updatedAt: string;
+}
+
+// ── Suggestion ranking input ────────────────────────────────────────────
+export interface SwapContext {
+  slot: DaySlot;
+  week: WeekPlan;
+  library: Meal[];
+  family: FamilyMember[];
+  reactions: MealReaction[];
+  rules: CadenceRule[];
+}
+
+/**
+ * Suggest 3 meals for a slot.
+ * Ranking signals (in order):
+ *   1. Not already used elsewhere this week.
+ *   2. Matches slot.theme tag if present.
+ *   3. Different protein than the meal being replaced.
+ *   4. Family likes outweigh family dislikes (sum signals).
+ *   5. Longest gap since last cooked (rotation freshness).
+ */
+export type SwapSuggester = (ctx: SwapContext) => Meal[];
+
+// ── Grocery aggregation ─────────────────────────────────────────────────
+export interface GroceryItem {
+  qty: string;
+  name: string;
+  fromMealIds: string[];  // which meals this came from
+  checked: boolean;
+}
+
+export interface GroceryList {
+  weekId: string;
+  byStore: Record<string, GroceryItem[]>;
+}

--- a/design/design-system.md
+++ b/design/design-system.md
@@ -1,0 +1,108 @@
+# Design System — Meal Assistant (Editorial)
+
+> A portable, calm aesthetic
+
+## Pillars
+
+1. **Paper, not glass.** The surface is warm off-white with hairline borders. No drop shadows on resting state, no glass blur. Depth comes from typography hierarchy and white space, not z-elevation.
+2. **One accent.** Forest green, used sparingly: primary buttons, sync state, "fits your rules" sparkles, theme pills, progress fills. Never decorative.
+3. **Editorial typography.** Display sizes go bigger than feels comfortable (44–56px). Body stays small (13–14px). The contrast does the work. Track in (-0.02 to -0.03em) at display sizes, neutral elsewhere.
+4. **Hairlines over boxes.** Lists are rule-divided. Cards exist but are quiet — paper-edge border, no shadow until hover.
+5. **Mono for metadata.** Anything technical (dates, durations, counts, identifiers, eyebrows) is in Geist Mono. Anything conversational is sans.
+6. **Motion is felt, not seen.** Fades and 4–8px slides at 160/220ms with one easing curve. No springs, no bounce, no choreography.
+
+## Type system
+
+| Role     | Family | Size  | Weight | Tracking | Use                                   |
+|----------|--------|-------|--------|----------|---------------------------------------|
+| display  | sans   | 56    | 500    | -0.03em  | Hero page title (Week)                |
+| h1       | sans   | 44    | 500    | -0.025em | Section landing titles                |
+| h2       | sans   | 28    | 500    | -0.02em  | Meal name in week timeline            |
+| h3       | sans   | 22    | 500    | -0.015em | Cuisine groupers, drawer titles       |
+| h4       | sans   | 18    | 500    | -0.01em  | Pane titles, store names              |
+| body     | sans   | 14    | 400    | 0        | Default body                          |
+| body-sm  | sans   | 13    | 400    | 0        | Card descriptions                     |
+| caption  | sans   | 12.5  | 400    | 0        | Field hints, footnotes                |
+| eyebrow  | mono   | 11    | 400    | 0.08em   | Section labels (UPPERCASE, ink-3)     |
+| mono-sm  | mono   | 12    | 400    | 0        | Date/duration metadata                |
+
+Always use `text-wrap: pretty` for body and `text-wrap: balance` for headlines.
+
+## Color
+
+A warm-paper / cool-slate palette anchored by a single forest accent. All colors are oklch so they tone-shift gracefully if you derive a dark mode.
+
+- **Surfaces:** paper → paper-2 (alt) → paper-edge (border)
+- **Text:** ink (primary) → ink-2 (secondary) → ink-3 (tertiary, eyebrows, metadata)
+- **Accent:** forest (action) / forest-2 (hover) / forest-soft (tinted bg)
+- **States:**
+  - amber-soft / amber-ink → kid notes, soft warnings
+  - rose-soft / rose-ink → dislikes, allergens
+  - slate-soft / slate-ink → neutral metadata pills
+
+See `tokens.json` for hex equivalents.
+
+## Spacing & rhythm
+
+Spacing scale: `0 2 4 6 8 10 12 14 16 20 24 28 32 40 48 56 64`.
+
+- Page horizontal padding: 64.
+- Page vertical padding: 32 top, 60 bottom.
+- Section gap: 32.
+- Hairline rule = `1px solid paper-edge`. Use it instead of cards for dense lists.
+
+Density is a setting (`compact` / `cozy` / `roomy`) that scales card and meal-row padding only — never type sizes.
+
+## Radii
+
+`xs 6 / sm 10 / md 14 / lg 20 / pill 999`. Pills for buttons and tags; md for cards; sm for form fields and tile icons.
+
+## Motion
+
+Two durations, one easing.
+
+- `fast = 160ms` for hover, press, color shifts.
+- `medium = 220ms` for entrances, drawers, fades.
+- Easing: `cubic-bezier(.2, .6, .2, 1)` always.
+- Entry: `opacity 0 → 1` + `translateY(4px → 0)`.
+- Drawer: `translateX(100% → 0)` over 220ms.
+- Honor `prefers-reduced-motion: reduce` — collapse all transforms; keep an 80ms opacity fade only.
+
+## Components (portable)
+
+The following are domain-agnostic and should be lifted into your shared UI library:
+
+- **Button** (`primary`, `ghost`, `default`, sizes `sm` `md`, `icon` variant).
+- **Pill** (`forest`, `slate`, `amber`, `rose` color modes).
+- **Card** (paper bg, paper-edge border, hairline hover shadow).
+- **Eyebrow** (the mono-uppercase label).
+- **Field + Label + Hint** (form primitives).
+- **Drawer** (right-side, 420 default, backdrop included).
+- **Modal** (centered, sticky footer pattern).
+- **HairlineList** (parent that gives all children a top border except the first).
+
+The following are meal-flavored but rebuildable elsewhere:
+
+- **CadencePulse** — 14-pip rotation indicator. The pattern (small linear pip array + mono caption) generalizes to any "time since" or "frequency" visual.
+- **KidNote** — name pill + free text in an amber tile. Generalizes to any annotated callout.
+
+## Iconography
+
+Custom 24×24 stroke icons (1.6 stroke, round caps/joins). Names in `atoms.jsx::Icon`. Don't substitute Heroicons or Lucide unless you re-tune the stroke weight to match — the weight is what makes them feel of-a-piece.
+
+## What to avoid
+
+- Drop shadows on resting cards.
+- Gradients.
+- Emoji as iconography.
+- Any color outside the palette (no system blues, no semantic reds — use rose-ink).
+- Generic stock icons.
+- Microcopy patterns: "Oops!", "delicious", "yummy", exclamation marks generally.
+- Pluralization tricks like "1 item(s)".
+
+## Adapting to dark mode (future)
+
+- Invert paper / ink: `paper` becomes `oklch(0.18 0.01 80)`, `ink` becomes `oklch(0.96 0.005 80)`.
+- Forest stays the same chroma but shifts lightness up by ~0.1.
+- Soft tints (amber/rose/slate) become low-chroma overlays with `mix-blend-mode: screen` or hand-tuned dark variants.
+- Hairlines become `oklch(0.28 0.008 80)`.

--- a/design/spec.md
+++ b/design/spec.md
@@ -1,0 +1,302 @@
+# Meal Assistant — Design Spec
+
+> **Stack target:** Next.js (app router), React, TypeScript.
+> **Design language:** see `tokens.json` and `design-system.md`.
+> **Source of truth for visuals:** the prototype in `Meal Assistant.html`.
+
+---
+
+## 0. Product summary
+
+A calm, family-scale meal planner. Plans the week, respects rotation rules (Taco Tuesday, Fish Friday, "no protein twice in 3 days"), reads a Skylight family calendar to skip nights when there's already a dinner plan, and prints per-kid modifications on the meal card so whoever is cooking can see them at a glance.
+
+**Household model:** 2 adults + 2 kids. Names in the prototype are placeholders (Mara, Dan, Iris, Theo) — replace with real values from auth.
+
+**Voice:** warm and friendly. Short sentences, sentence case, never sales-y, never apologetic. Examples that hit:
+- "This week, we're cooking."
+- "No dinner planned" (not "No meals scheduled")
+- "Fits your rules"
+- "Plan looks healthy"
+
+---
+
+## 1. Information architecture
+
+```
+/                         → Week (default)
+/library                  → Library
+/cadence                  → Cadence
+/grocery                  → Grocery
+/settings/family          → Family preferences
+/settings/calendar        → Calendar sync
+/library/new              → Add meal (modal route)
+```
+
+The top nav is always visible. Sync status (dot + last-sync time) lives top-right.
+
+---
+
+## 2. Screens
+
+### 2.1 Week (`/`)
+
+The hero. A vertical timeline of the 7 days of the current week.
+
+**Header**
+- Eyebrow: `"Apr 27 — May 03 · Issue 17"` — date range + week number.
+- Display title: `"This week, we're cooking."` (display token, balance-wrapped).
+- Right-side actions: `Regenerate` (ghost button) and `Email this` (primary button).
+
+**Day rows** — one row per day, separated by hairline rules. Three columns:
+
+| col | width | content |
+|-----|-------|---------|
+| 1   | 120px | `MON` (mono) over `Apr 27`; theme pill underneath if applicable |
+| 2   | flex  | meal name (h2), metadata row, event chip, kid-mod notes |
+| 3   | 320px | thumb-up / thumb-down toggle, then `Swap meal` |
+
+**Skip nights** — when an event has `impact: "skip"`, render the meal slot italic and muted: *"No dinner planned"*, with the event chip below. Replace actions with a single `Plan a meal` ghost button.
+
+**Metadata row** (below meal name, mono caption):
+`{protein} · {prep} min · {N}d ago` (the "Nd ago" is an inline `<CadencePulse>`).
+
+**Kid mods** — for each kid whose `mods[].match` substring is in the meal name, render a `<KidNote>` (amber chip with name pill on the left).
+
+**Event chip** — only render when `event && !theme` to avoid a doubled visual.
+
+**Theme pill** — only Tuesday and Friday currently. Pill is forest-soft + forest-2; icon prefixed (`taco` or `fish`).
+
+**Reactions** — clicking the same direction twice clears it. Persist per `mealId` (not per slot — feedback is about the meal, not the day).
+
+**Swap CTA** — opens the right-side drawer (see §3.1).
+
+### 2.2 Library (`/library`)
+
+Editorial listing of every meal. Header: eyebrow with count + cuisine grouping mode, h1 `"Meals we make"`, primary action `Add meal`.
+
+Meals grouped by `cuisine`. Each cuisine block: h3 with the name (capitalized) + count, then a 2-column rule-divided list. Each row: meal name (h4), mono metadata `{protein} · {prep}m · {source}`, optional italic notes, right-aligned `<CadencePulse>`.
+
+No cards, no boxes. The hairline rules do all the work.
+
+### 2.3 Cadence (`/cadence`)
+
+Two-up: protein mix (left) + active rules (right), then a stacked history of the last 3 weeks.
+
+**Protein mix** — a list of horizontal progress bars, one per protein, sorted desc. Bar uses `forest`; track uses `paper-edge`. Trailing mono count.
+
+**Active rules** — list of cards with a green check tile + title + detail. Tap to edit (not yet implemented).
+
+**Last 3 weeks** — for each historical week, eyebrow `"Week of Apr 20"`, then an inline run of `{day} {meal name}` separated by gaps. Skip nights are simply absent.
+
+### 2.4 Grocery (`/grocery`)
+
+3-column layout, one column per store. Each store has h3 store name and a list of items with checkbox + mono qty + name. Items separated by hairlines, no card.
+
+Right side of the header has an `Email this list` primary button.
+
+### 2.5 Settings — Family (`/settings/family`)
+
+Left rail with two sections (`Family`, `Calendar`). Right pane:
+
+For each family member: forest-soft avatar tile (initial), name + role eyebrow, then a 2-col grid:
+- `Likes` — forest pills.
+- `Dislikes` — rose pills.
+- `Allergens` (if any) — amber pills.
+- `Standing mods` (if any) — list of `{when "match"} {text}` lines.
+
+Each member has a small `Edit` ghost button. Bottom of the pane: `+ Add family member`.
+
+**Behavior:** mods are surfaced on the Week screen via `modsForMeal()` — a kid's mod whose `match` is a substring of the meal name renders as a `<KidNote>`. Likes/dislikes inform `swapSuggestions()` ranking (not yet implemented in prototype, but specced).
+
+### 2.6 Settings — Calendar (`/settings/calendar`)
+
+A single connection card:
+- Skylight icon tile (ink filled), provider name, account email or "Not connected".
+- Right side: `Disconnect` (when connected) or `Connect` (when not).
+- When connected, divider then:
+  - Last sync row: title + mono time + `Sync now` ghost button on the right.
+  - Synced calendars: row of slate pills.
+
+Footer caption (ink-3): "Events are read-only. We use them to suggest skip nights and quick-meal days — never to modify your calendar."
+
+**Skylight integration note for engineering:** Skylight does not have a public OAuth API at time of writing. Integration path is likely (a) iCal feed URL paste, or (b) Google/Apple calendar shared with Skylight. Treat the UI as provider-agnostic — the `provider` field in `SyncState` is the only thing that needs to change to support Google/Apple/iCloud.
+
+### 2.7 Add Meal (`/library/new`, modal)
+
+Centered card, 640px wide, max 90% viewport height. Header: eyebrow `"New meal"` + h3 title `"Add to your library"`. Sticky footer with `Cancel` + `Save meal`.
+
+Fields (in order):
+1. **Name** (text)
+2. **Source URL** (text) + **Cuisine** (select) — side by side
+3. **Themes** (multi-select toggle buttons — Taco Tuesday, Fish Friday)
+4. **Ingredients** (mono textarea, hint: "One per line — used for grocery generation")
+5. **Notes** (textarea, hint: "Cooking tips, family lore, who likes it")
+6. **Photo** (drop zone)
+
+All fields are optional except name. Saving routes back to `/library`.
+
+---
+
+## 3. Components
+
+### 3.1 SwapDrawer (right-side, 420px)
+
+Opens when user clicks `Swap` on any meal row. Backdrop fades in over the page; drawer slides in from the right (220ms).
+
+- Header: eyebrow with day + date, h3 "Choose a swap", caption "Replacing: {current name}", close button.
+- Body: eyebrow "Fits your rules" with sparkle icon, then 3 suggestion buttons separated by hairlines:
+  - Meal name (h4)
+  - Slate pills: protein, prep time
+  - `<CadencePulse>` showing last-made
+- Tapping a suggestion replaces the meal and closes the drawer (220ms reverse).
+
+**Suggestion ranking** (`swapSuggestions(daySlot)`):
+1. Exclude meals already used elsewhere in the current week.
+2. Boost meals whose `themes` include the slot's theme tag.
+3. Boost meals with a *different* protein than the current slot's meal.
+4. Future: weight by family member likes/dislikes (currently not factored).
+5. Take top 3.
+
+### 3.2 KidNote (amber chip)
+
+`<KidNote note={{ who, text }} />` — name pill on the left, free text on the right. Background `amber-soft`, text `amber-ink`. Used on Week meal rows and (future) on shopping list per-meal annotations.
+
+### 3.3 CadencePulse
+
+14 vertical pips. The N most-recent days are filled forest, older days are paper-edge. Trailing mono "Nd ago" caption. Communicates rotation gap visually.
+
+### 3.4 EventChip
+
+Pill component. `pill-slate` for skip events, `pill-amber` for impact events (quick-meal, time-shift). Icon prefix maps to event kind (`soccer`, `dinner-out`, `calendar`).
+
+### 3.5 Standard buttons
+
+- `btn` — pill, paper bg, paper-edge border, ink text.
+- `btn-primary` — forest bg, paper text.
+- `btn-ghost` — transparent border.
+- `btn-sm` — 12px font, tighter padding.
+- `btn-icon` — square 28×28.
+
+All buttons share the same hover/press transitions defined in tokens.
+
+---
+
+## 4. Data model (suggested TypeScript)
+
+```ts
+type Protein = 'fish' | 'chicken' | 'beef' | 'pork' | 'turkey' | 'shrimp' | 'veg';
+type Cuisine = 'simple' | 'italian' | 'tex-mex' | 'asian' | 'mediterranean' | 'american';
+type ThemeTag = 'taco-tuesday' | 'fish-friday';
+
+interface Meal {
+  id: string;
+  name: string;
+  protein: Protein;
+  cuisine: Cuisine;
+  themes: ThemeTag[];
+  prep: number;             // minutes
+  source?: string;          // recipe origin (URL or human label)
+  notes?: string;
+  ingredients?: Ingredient[];
+  photoUrl?: string;
+  // server-computed:
+  lastMade?: string;        // ISO date
+  timesThisMonth?: number;
+  rating?: number;
+}
+
+interface Ingredient { qty: string; name: string; store?: string; }
+
+interface FamilyMember {
+  id: string;
+  name: string;
+  role: 'adult' | 'kid';
+  age?: number;
+  avatar: string;
+  likes: string[];
+  dislikes: string[];
+  allergens: string[];
+  mods: { match: string; text: string }[]; // substring match against meal.name
+}
+
+interface DaySlot {
+  day: 'MON'|'TUE'|'WED'|'THU'|'FRI'|'SAT'|'SUN';
+  date: string;             // 'Apr 27'
+  isoDate: string;
+  mealId: string | null;
+  theme: string | null;     // display label; tag derived from this string
+  event: CalendarEvent | null;
+}
+
+interface CalendarEvent {
+  kind: 'soccer' | 'dinner-out' | 'work' | 'travel' | 'other';
+  label: string;
+  impact: 'skip' | 'quick-meal' | 'shift-time' | 'none';
+  startsAt?: string;
+}
+
+interface SyncState {
+  connected: boolean;
+  provider: 'skylight' | 'google' | 'apple' | 'ical';
+  account?: string;
+  lastSync?: string;        // ISO timestamp
+  calendars: string[];
+}
+
+interface CadenceRule {
+  id: string;
+  label: string;
+  detail: string;
+  // server-side enforcement schema TBD
+}
+```
+
+---
+
+## 5. Behaviors & state
+
+### 5.1 Persistence
+- Reactions (`thumb up/down`) live on `meal_ratings` keyed by `(userId, mealId)`. They affect future suggestion ranking but never automatically remove a meal from the library.
+- Swapping a meal writes to a `week_plan` record (one per week). Server returns regenerated grocery list.
+- "Email this" / "Email this list" — use Resend or similar; render a server-side text+HTML email mirroring the screen content.
+
+### 5.2 Week regeneration
+"Regenerate" should preserve any meal the user has explicitly reacted to (👍 sticks, 👎 forces a swap). Always preserve skip nights derived from calendar events.
+
+### 5.3 Calendar polling
+Pull on open + every 15 min while the tab is focused. Surface `lastSync` next to the dot. The "Sync now" button forces a refresh.
+
+### 5.4 Mod resolution
+Mods are matched case-insensitive substring on meal name. Future improvement: structured tags (e.g. `mod: { match: { ingredient: 'beans' }, text: '...' }`).
+
+---
+
+## 6. Accessibility
+
+- Hit targets ≥ 32px (we use 28px icon buttons — bump to 32 on touch).
+- `aria-label` on every icon-only button. The prototype tags `Like`, `Dislike`, `Close`.
+- Keyboard: drawer should trap focus and close on `Esc`.
+- Color: forest-on-paper passes AA. Amber-ink on amber-soft passes AA at 12.5px+.
+- Motion: respect `prefers-reduced-motion` — collapse all 220ms slides to instant + 80ms fade.
+
+---
+
+## 7. Out of scope (next phase)
+
+- Per-meal photo upload (currently a stub).
+- Multi-week planning view.
+- Recipe instruction view.
+- Meal scaling for guests.
+- Pantry / inventory.
+- Push to family calendar (one-way read for now).
+
+---
+
+## 8. Implementation notes for Claude Code
+
+1. **Tokens first.** Convert `tokens.json` to CSS custom properties on `:root`. Don't reach into the prototype's class names — the visual contract is the tokens.
+2. **Component library.** The components in §3 are the floor. Build them as headless + styled in Next.js using the tokens.
+3. **Routes.** Use the app router. Settings is a nested layout with the left rail. Add Meal is an intercepted/parallel route on `/library`.
+4. **Server state.** Wrap meal/week/family/sync in server components; reactions/swaps via server actions.
+5. **Auth + accounts.** Out of scope for this design pass — prototype assumes a logged-in family.
+6. **Avoid:** drop shadows on cards (we use 1px hairlines), gradients, generic emoji food icons (use the custom Icon set), and the words "delicious" or "yummy" anywhere in the UI.

--- a/design/tokens.json
+++ b/design/tokens.json
@@ -1,0 +1,94 @@
+{
+  "$schema": "./tokens.schema.md",
+  "name": "Meal Assistant — Editorial",
+  "version": "1.0.0",
+  "description": "Calm, typography-forward design system. Paper + ink + a single forest accent. Portable to any web stack.",
+
+  "color": {
+    "paper":        { "value": "oklch(0.985 0.005 80)",  "comment": "Page background, primary surface" },
+    "paper-2":      { "value": "oklch(0.975 0.006 80)",  "comment": "Subtle alt surface (modal footers, hover)" },
+    "paper-edge":   { "value": "oklch(0.92 0.008 80)",   "comment": "Hairline borders, dividers" },
+    "ink":          { "value": "oklch(0.22 0.01 80)",    "comment": "Primary text, mark" },
+    "ink-2":        { "value": "oklch(0.42 0.01 80)",    "comment": "Secondary text, nav resting" },
+    "ink-3":        { "value": "oklch(0.62 0.01 80)",    "comment": "Tertiary text, metadata, eyebrows" },
+    "forest":       { "value": "oklch(0.42 0.08 145)",   "comment": "Single accent. Primary buttons, sync state, theme pills, progress" },
+    "forest-2":     { "value": "oklch(0.34 0.08 145)",   "comment": "Hover/active for accent" },
+    "forest-soft":  { "value": "oklch(0.94 0.025 145)",  "comment": "Tinted background for forest text/icons" },
+    "amber-soft":   { "value": "oklch(0.93 0.04 75)",    "comment": "Kid notes, soft warnings" },
+    "amber-ink":    { "value": "oklch(0.45 0.08 60)",    "comment": "Text on amber-soft" },
+    "slate-soft":   { "value": "oklch(0.92 0.008 240)",  "comment": "Neutral pills, metadata chips" },
+    "slate-ink":    { "value": "oklch(0.45 0.01 240)",   "comment": "Text on slate-soft" },
+    "rose-soft":    { "value": "oklch(0.93 0.03 25)",    "comment": "Dislike state, allergens" },
+    "rose-ink":     { "value": "oklch(0.5 0.08 25)",     "comment": "Text on rose-soft" }
+  },
+
+  "font": {
+    "sans": { "value": "'Geist', ui-sans-serif, system-ui, -apple-system, 'Helvetica Neue', sans-serif", "import": "https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600&display=swap" },
+    "mono": { "value": "'Geist Mono', ui-monospace, 'SF Mono', Menlo, monospace",                        "import": "https://fonts.googleapis.com/css2?family=Geist+Mono:wght@400;500&display=swap" }
+  },
+
+  "type": {
+    "display":    { "size": "56px", "weight": 500, "tracking": "-0.03em",  "line": 1.0,  "use": "Page title (Week 'This week, we're cooking')" },
+    "h1":         { "size": "44px", "weight": 500, "tracking": "-0.025em", "line": 1.05, "use": "Section page titles" },
+    "h2":         { "size": "28px", "weight": 500, "tracking": "-0.02em",  "line": 1.15, "use": "Meal name in week timeline" },
+    "h3":         { "size": "22px", "weight": 500, "tracking": "-0.015em", "line": 1.2,  "use": "Cuisine groupers, drawer titles" },
+    "h4":         { "size": "18px", "weight": 500, "tracking": "-0.01em",  "line": 1.3,  "use": "Pane titles, store names" },
+    "body":       { "size": "14px", "weight": 400, "tracking": "0",        "line": 1.5,  "use": "Default body" },
+    "body-sm":    { "size": "13px", "weight": 400, "tracking": "0",        "line": 1.5,  "use": "Card descriptions" },
+    "caption":    { "size": "12.5px","weight": 400,"tracking": "0",        "line": 1.5,  "use": "Hints under fields" },
+    "eyebrow":    { "size": "11px", "weight": 400, "tracking": "0.08em",   "line": 1.0,  "transform": "uppercase", "family": "mono", "color": "ink-3", "use": "Section labels, metadata headers" },
+    "mono-sm":    { "size": "12px", "weight": 400, "tracking": "0",        "line": 1.4,  "family": "mono", "use": "Date stamps, technical metadata" }
+  },
+
+  "radius": {
+    "xs": "6px",
+    "sm": "10px",
+    "md": "14px",
+    "lg": "20px",
+    "pill": "999px"
+  },
+
+  "spacing": {
+    "scale": [0, 2, 4, 6, 8, 10, 12, 14, 16, 20, 24, 28, 32, 40, 48, 56, 64],
+    "page-x": "64px",
+    "page-y": "32px",
+    "card-pad-cozy": "18px",
+    "card-pad-compact": "12px",
+    "card-pad-roomy":  "26px",
+    "row-gap-week": "0px",
+    "section-gap": "32px"
+  },
+
+  "shadow": {
+    "card": "0 1px 0 oklch(0.95 0.005 80), 0 1px 2px oklch(0.85 0.01 80 / 0.35)",
+    "pop":  "0 8px 24px -8px oklch(0.4 0.02 80 / 0.18), 0 2px 6px oklch(0.5 0.02 80 / 0.08)"
+  },
+
+  "motion": {
+    "principles": [
+      "Minimal: fades and small (4–8px) slides only. No bouncy springs.",
+      "Durations live in two buckets: fast (160ms) for hover/press, medium (220ms) for entrances and drawers.",
+      "Easing is always cubic-bezier(.2,.6,.2,1) — settled, never showy."
+    ],
+    "duration": { "fast": "160ms", "medium": "220ms" },
+    "easing":   { "default": "cubic-bezier(.2,.6,.2,1)" },
+    "transitions": {
+      "hover":         "background 160ms, color 160ms",
+      "card":          "box-shadow 160ms, border-color 160ms",
+      "drawer":        "transform 220ms cubic-bezier(.2,.6,.2,1)",
+      "backdrop":      "opacity 220ms cubic-bezier(.2,.6,.2,1)",
+      "fade-in-entry": "opacity 220ms, transform 220ms (translateY 4px → 0)"
+    }
+  },
+
+  "density": {
+    "compact": { "card-pad": "12px", "meal-pad": "10px", "week-gap": "10px" },
+    "cozy":    { "card-pad": "18px", "meal-pad": "16px", "week-gap": "14px" },
+    "roomy":   { "card-pad": "26px", "meal-pad": "22px", "week-gap": "20px" }
+  },
+
+  "icon": {
+    "set": "Custom 24x24 stroke icons (1.6 stroke, round caps/joins). Listed in atoms.jsx::Icon",
+    "size": { "xs": 10, "sm": 12, "md": 14, "lg": 18, "xl": 24 }
+  }
+}

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -1,143 +1,58 @@
 # Meal Assistant Design System
 
-## Brand Direction
+The canonical design system for this app is the **Editorial** system delivered in the `design/` handoff folder at the repo root.
 
-Earthy, organic, and homey. The visual identity evokes a warm kitchen — olive greens, terracotta, and warm browns. The palette feels rustic and inviting without being heavy or muddy.
+- **Pillars, type scale, color, motion, components:** [`design/design-system.md`](../design/design-system.md)
+- **Machine-readable tokens:** [`design/tokens.json`](../design/tokens.json)
+- **Screen-by-screen spec:** [`design/spec.md`](../design/spec.md)
+- **Suggested data model:** [`design/data-model.ts`](../design/data-model.ts)
+- **Source-of-truth prototype:** `design/Meal Assistant.html`
 
-## Color Palette
+The previous olive/terracotta system this file documented is retired — see issue #86 for the makeover.
 
-All colors use the oklch color space for perceptual uniformity. Values are defined as CSS variables in `src/app/globals.css`.
+## Where the tokens live in code
 
-### Primary Colors
+- `src/app/globals.css` — Editorial tokens declared as CSS custom properties on `:root` (`--paper`, `--ink`, `--forest`, `--paper-edge`, `--forest-soft`, `--amber-soft`/`--amber-ink`, `--slate-soft`/`--slate-ink`, `--rose-soft`/`--rose-ink`, `--ink-2`, `--ink-3`, `--forest-2`).
+- The same file's `@theme inline` block exposes them as Tailwind utilities: `bg-paper`, `text-ink`, `border-paper-edge`, `bg-forest-soft text-forest-2`, etc.
+- The shadcn semantic tokens (`--background`, `--foreground`, `--primary`, `--muted`, `--border`, …) are re-bound to the Editorial palette so existing primitives keep rendering with the new colors.
 
-| Token | Light Mode | Dark Mode | Purpose |
-|-------|-----------|-----------|---------|
-| `--primary` | `oklch(0.47 0.10 138)` — muted olive | `oklch(0.62 0.13 138)` — lighter olive | Primary actions, active states, brand identity |
-| `--primary-foreground` | `oklch(0.99 0 0)` — white | `oklch(0.16 0.02 138)` — dark olive | Text on primary backgrounds |
+## What's authoritative
 
-### Accent Colors
+When in doubt, **`design/tokens.json` is the visual contract**. Don't pixel-match against the prototype HTML — match against the tokens. If you find a discrepancy between this README, `design/design-system.md`, and `tokens.json`, trust `tokens.json` and file a doc fix.
 
-| Token | Light Mode | Dark Mode | Purpose |
-|-------|-----------|-----------|---------|
-| `--accent` | `oklch(0.90 0.04 38)` — soft terracotta | `oklch(0.35 0.04 38)` — deep terracotta | Hover states, highlighted sections, visual warmth |
-| `--accent-foreground` | `oklch(0.25 0.03 40)` — dark warm | `oklch(0.93 0.008 75)` — light | Text on accent backgrounds |
+## Quick reference
 
-### Semantic Colors
+### Colors
 
-| Token | Light Mode | Dark Mode | Purpose |
-|-------|-----------|-----------|---------|
-| `--success` | `oklch(0.55 0.16 150)` — bright green | `oklch(0.62 0.14 150)` — lighter green | Success states, confirmations. Hue 150 is intentionally brighter and more saturated than olive primary (hue 138) for clear distinction. |
-| `--warning` | `oklch(0.75 0.12 70)` — warm amber | `oklch(0.72 0.11 70)` — muted amber | Warning states, demo indicators |
-| `--destructive` | `oklch(0.577 0.245 27)` — red | `oklch(0.704 0.191 22)` — lighter red | Destructive actions, errors |
+| Surface | Token | Use |
+|---|---|---|
+| `--paper` | page bg, primary surface |
+| `--paper-2` | alt surface (hover, modal footers) |
+| `--paper-edge` | hairline borders, dividers |
+| `--ink` | primary text |
+| `--ink-2` | secondary text, nav resting |
+| `--ink-3` | tertiary text, eyebrows, metadata |
+| `--forest` | single accent — primary buttons, sync state, theme pills, progress |
+| `--forest-2` | hover/active for accent |
+| `--forest-soft` | tinted bg behind forest text/icons |
+| `--amber-soft` / `--amber-ink` | kid notes, soft warnings |
+| `--slate-soft` / `--slate-ink` | neutral metadata pills |
+| `--rose-soft` / `--rose-ink` | dislikes, allergens |
 
-### Neutral Colors
+### Typography utilities
 
-| Token | Light Mode | Dark Mode | Purpose |
-|-------|-----------|-----------|---------|
-| `--background` | `oklch(0.985 0.005 75)` — warm off-white | `oklch(0.17 0.015 65)` — warm dark | Page background |
-| `--foreground` | `oklch(0.20 0.02 65)` — warm near-black | `oklch(0.93 0.008 75)` — warm near-white | Body text |
-| `--muted` | `oklch(0.94 0.012 75)` — warm light gray | `oklch(0.28 0.012 65)` — warm dark gray | Subdued backgrounds |
-| `--muted-foreground` | `oklch(0.48 0.02 65)` — warm mid-gray | `oklch(0.63 0.02 65)` — warm mid-gray | Secondary text |
-| `--secondary` | `oklch(0.95 0.015 75)` — warm cream | `oklch(0.28 0.015 65)` — warm dark | Secondary buttons, subtle surfaces |
-| `--border` | `oklch(0.90 0.015 75)` — warm border | `oklch(1 0.008 75 / 12%)` — translucent warm | Borders, dividers |
-| `--card` | `oklch(0.995 0.003 75)` — near white | `oklch(0.22 0.015 65)` — dark surface | Card backgrounds |
+`text-display` (56) · `text-h1` (44) · `text-h2` (28) · `text-h3` (22) · `text-h4` (18) · `text-body` (14) · `text-body-sm` (13) · `text-caption` (12.5) · `text-eyebrow` (11, mono, uppercase, tracked) · `text-mono-sm` (12, mono).
 
-### Design Principles for Colors
+### Radii
 
-- **All neutrals carry warm undertones** (hue 65-75) — never use pure gray (hue 0, chroma 0)
-- **Primary (olive, hue 138)** is distinct from success (bright green, hue 150) — primary is muted, success is vivid
-- **Accent (terracotta, hue 38)** adds visual warmth without competing with primary
-- **Maintain WCAG AA contrast** (4.5:1 minimum) for all text on background combinations
-- **Dark mode uses higher chroma** to keep earthy tones vibrant on dark surfaces
+`rounded-xs` (6) · `rounded-sm` (10) · `rounded-md` (14, default) · `rounded-lg` (20) · `rounded-pill` (9999).
 
-## Typography
+### Motion
 
-| Element | Font | Weight | Size |
-|---------|------|--------|------|
-| Body text | Geist Sans (`--font-sans`) | 400 | `text-sm` (14px) |
-| Headings (h1) | Geist Sans | 700 (`font-bold`) | `text-2xl` (24px) |
-| Headings (h2) | Geist Sans | 600 (`font-semibold`) | `text-lg` (18px) |
-| Section labels | Geist Sans | 600 | `text-sm uppercase tracking-wide` |
-| Monospace/code | Geist Mono (`--font-mono`) | 400 | Inherited |
-| Metadata | Geist Sans | 400 | `text-xs` (12px) |
+Two durations, one easing.
 
-### Typography Principles
-
-- Use `font-bold` for page titles, `font-semibold` for section headers, `font-medium` for interactive labels
-- Section labels use `text-sm font-semibold uppercase tracking-wide text-muted-foreground`
-- Do not use fonts other than Geist Sans and Geist Mono
-
-## Spacing
-
-| Context | Value | Usage |
-|---------|-------|-------|
-| Page padding | `px-4` | Horizontal padding on main content |
-| Section gap | `space-y-6` | Between major page sections |
-| Card internal | `CardContent` default | Content within cards |
-| Form fields | `space-y-2` | Between label and input, between fields |
-| Inline items | `gap-2` | Between buttons, badges, inline elements |
-| Container max width | `max-w-3xl mx-auto` | All page content |
-
-## Border Radius
-
-Uses shadcn's radius scale based on `--radius: 0.625rem`:
-
-| Token | Value | Usage |
-|-------|-------|-------|
-| `rounded-sm` | 3.75px | Small elements, inner borders |
-| `rounded-md` | 5px | Inputs, small cards |
-| `rounded-lg` | 10px | Cards, buttons (default) |
-| `rounded-xl` | 14px | Large containers |
-| `rounded-4xl` | 16.25px | Pill-shaped badges |
-
-## Component Usage
-
-### Buttons
-- Use `<Button>` from `@/components/ui/button` for all interactive buttons
-- For links styled as buttons, use `buttonVariants()` as className on `<Link>` elements
-- Primary actions: `variant="default"` (olive green)
-- Secondary actions: `variant="outline"` or `variant="secondary"`
-- Destructive actions: `variant="destructive"` (red)
-- Icon-only: `size="icon"` or `size="icon-sm"`
-
-### Badges
-- Use `<Badge>` from `@/components/ui/badge` for all status indicators and tags
-- Tags: `variant="secondary"`
-- Active filters: `variant="default"` (primary olive)
-- Status indicators: use semantic color classes (`bg-success/15 text-success`, `bg-warning/15 text-warning`)
-
-### Cards
-- Use `<Card>` compound component for content sections
-- Recipe cards use `Card` with hover states (`hover:bg-accent/60`)
-- Detail page sections use `Card > CardContent` with section headers
-
-### Form Elements
-- Always use shadcn `Input`, `Textarea`, `Label` — never raw HTML form elements
-- Group related numeric fields in a `bg-accent/50 rounded-xl p-4` container
-- Use icon labels with `text-primary/70` for visual context
-
-### Toast Notifications
-- Use `sonner` via `toast()`, `toast.success()`, `toast.error()`
-- Position: `bottom-center` (matches centered layout)
-- Use for transient success/error feedback
-- Keep auth-specific errors inline (not just toasts) when user interaction is needed
-
-### Dialogs
-- Use shadcn `Dialog` for confirmations — never `window.confirm()` or `window.alert()`
-- Destructive confirmations: Cancel + destructive action button
-
-### Loading States
-- Use `<Skeleton>` for content-shaped loading placeholders
-- Match skeleton layout to the real content shape (cards, text lines, metadata rows)
-
-### Separators
-- Use `<Separator>` between major content sections
-- Provides clear visual hierarchy without heavy borders
-
-## Dark Mode
-
-- Dark mode is supported via `.dark` class on the HTML element
-- All components inherit dark mode automatically through CSS variables
-- Dark backgrounds use warm undertones (hue 65) — never pure black
-- Primary and success colors increase chroma in dark mode for vibrancy
-- Borders use translucent warm overlays (`oklch(1 0.008 75 / 12%)`)
+- `duration-fast` = 160ms — hover, press, color shifts.
+- `duration-medium` = 220ms — entrances, drawers, fades.
+- `ease-editorial` = `cubic-bezier(.2,.6,.2,1)`.
+- Entry pattern: `opacity 0 → 1` + `translateY(4px → 0)`.
+- `prefers-reduced-motion: reduce` collapses transforms to an 80ms opacity fade (handled in `globals.css`).

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4,128 +4,219 @@
 
 @custom-variant dark (&:is(.dark *));
 
+/* ──────────────────────────────────────────────────────────────────────────
+   Editorial design system tokens — see design/design-system.md
+   Named tokens (--paper, --ink, --forest, …) are the source of truth.
+   shadcn's semantic tokens (--background, --primary, …) are re-bound to
+   them so existing primitives keep rendering while new components consume
+   the named tokens directly.
+   ────────────────────────────────────────────────────────────────────── */
+
+:root {
+  /* Editorial palette */
+  --paper:        oklch(0.985 0.005 80);
+  --paper-2:      oklch(0.975 0.006 80);
+  --paper-edge:   oklch(0.92 0.008 80);
+  --ink:          oklch(0.22 0.01 80);
+  --ink-2:        oklch(0.42 0.01 80);
+  --ink-3:        oklch(0.62 0.01 80);
+  --forest:       oklch(0.42 0.08 145);
+  --forest-2:     oklch(0.34 0.08 145);
+  --forest-soft:  oklch(0.94 0.025 145);
+  --amber-soft:   oklch(0.93 0.04 75);
+  --amber-ink:    oklch(0.45 0.08 60);
+  --slate-soft:   oklch(0.92 0.008 240);
+  --slate-ink:    oklch(0.45 0.01 240);
+  --rose-soft:    oklch(0.93 0.03 25);
+  --rose-ink:     oklch(0.5 0.08 25);
+
+  /* Motion */
+  --ease-editorial: cubic-bezier(.2, .6, .2, 1);
+  --duration-fast:   160ms;
+  --duration-medium: 220ms;
+
+  /* shadcn semantic tokens, rebound to Editorial palette */
+  --background: var(--paper);
+  --foreground: var(--ink);
+  --card: var(--paper);
+  --card-foreground: var(--ink);
+  --popover: var(--paper);
+  --popover-foreground: var(--ink);
+  --primary: var(--forest);
+  --primary-foreground: var(--paper);
+  --secondary: var(--paper-2);
+  --secondary-foreground: var(--ink);
+  --muted: var(--paper-2);
+  --muted-foreground: var(--ink-3);
+  --accent: var(--forest-soft);
+  --accent-foreground: var(--forest-2);
+  --destructive: var(--rose-ink);
+  --success: var(--forest);
+  --success-foreground: var(--paper);
+  --warning: var(--amber-ink);
+  --warning-foreground: var(--paper);
+  --border: var(--paper-edge);
+  --input: var(--paper-edge);
+  --ring: var(--forest);
+
+  /* Charts (kept for any future viz; tuned to Editorial palette) */
+  --chart-1: var(--forest);
+  --chart-2: var(--amber-ink);
+  --chart-3: var(--rose-ink);
+  --chart-4: var(--slate-ink);
+  --chart-5: var(--ink-2);
+
+  --radius: 14px; /* md */
+
+  --sidebar: var(--paper-2);
+  --sidebar-foreground: var(--ink);
+  --sidebar-primary: var(--forest);
+  --sidebar-primary-foreground: var(--paper);
+  --sidebar-accent: var(--forest-soft);
+  --sidebar-accent-foreground: var(--forest-2);
+  --sidebar-border: var(--paper-edge);
+  --sidebar-ring: var(--forest);
+}
+
+.dark {
+  /* Editorial dark mode (per design-system.md §"Adapting to dark mode") */
+  --paper:        oklch(0.18 0.01 80);
+  --paper-2:      oklch(0.21 0.01 80);
+  --paper-edge:   oklch(0.28 0.008 80);
+  --ink:          oklch(0.96 0.005 80);
+  --ink-2:        oklch(0.78 0.005 80);
+  --ink-3:        oklch(0.6 0.008 80);
+  --forest:       oklch(0.52 0.08 145);
+  --forest-2:     oklch(0.6 0.09 145);
+  --forest-soft:  oklch(0.28 0.04 145);
+  --amber-soft:   oklch(0.3 0.04 75);
+  --amber-ink:    oklch(0.78 0.08 75);
+  --slate-soft:   oklch(0.28 0.008 240);
+  --slate-ink:    oklch(0.78 0.01 240);
+  --rose-soft:    oklch(0.3 0.04 25);
+  --rose-ink:     oklch(0.78 0.08 25);
+}
+
+/* ──────────────────────────────────────────────────────────────────────────
+   Tailwind v4 theme — exposes the named tokens as utility classes
+   (e.g. `bg-paper`, `text-ink`, `border-paper-edge`, `text-display`,
+   `duration-fast`, `ease-editorial`).
+   ────────────────────────────────────────────────────────────────────── */
+
 @theme inline {
+  /* Color utilities */
+  --color-paper: var(--paper);
+  --color-paper-2: var(--paper-2);
+  --color-paper-edge: var(--paper-edge);
+  --color-ink: var(--ink);
+  --color-ink-2: var(--ink-2);
+  --color-ink-3: var(--ink-3);
+  --color-forest: var(--forest);
+  --color-forest-2: var(--forest-2);
+  --color-forest-soft: var(--forest-soft);
+  --color-amber-soft: var(--amber-soft);
+  --color-amber-ink: var(--amber-ink);
+  --color-slate-soft: var(--slate-soft);
+  --color-slate-ink: var(--slate-ink);
+  --color-rose-soft: var(--rose-soft);
+  --color-rose-ink: var(--rose-ink);
+
+  /* shadcn-compatible aliases (kept so existing primitives keep working) */
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: var(--font-sans);
-  --font-mono: var(--font-geist-mono);
-  --color-sidebar-ring: var(--sidebar-ring);
-  --color-sidebar-border: var(--sidebar-border);
-  --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
-  --color-sidebar-accent: var(--sidebar-accent);
-  --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
-  --color-sidebar-primary: var(--sidebar-primary);
-  --color-sidebar-foreground: var(--sidebar-foreground);
-  --color-sidebar: var(--sidebar);
-  --color-chart-5: var(--chart-5);
-  --color-chart-4: var(--chart-4);
-  --color-chart-3: var(--chart-3);
-  --color-chart-2: var(--chart-2);
-  --color-chart-1: var(--chart-1);
-  --color-ring: var(--ring);
-  --color-input: var(--input);
-  --color-border: var(--border);
-  --color-destructive: var(--destructive);
-  --color-accent-foreground: var(--accent-foreground);
-  --color-accent: var(--accent);
-  --color-muted-foreground: var(--muted-foreground);
-  --color-muted: var(--muted);
-  --color-secondary-foreground: var(--secondary-foreground);
-  --color-secondary: var(--secondary);
-  --color-primary-foreground: var(--primary-foreground);
-  --color-primary: var(--primary);
-  --color-popover-foreground: var(--popover-foreground);
-  --color-popover: var(--popover);
-  --color-card-foreground: var(--card-foreground);
   --color-card: var(--card);
+  --color-card-foreground: var(--card-foreground);
+  --color-popover: var(--popover);
+  --color-popover-foreground: var(--popover-foreground);
+  --color-primary: var(--primary);
+  --color-primary-foreground: var(--primary-foreground);
+  --color-secondary: var(--secondary);
+  --color-secondary-foreground: var(--secondary-foreground);
+  --color-muted: var(--muted);
+  --color-muted-foreground: var(--muted-foreground);
+  --color-accent: var(--accent);
+  --color-accent-foreground: var(--accent-foreground);
+  --color-destructive: var(--destructive);
   --color-success: var(--success);
   --color-success-foreground: var(--success-foreground);
   --color-warning: var(--warning);
   --color-warning-foreground: var(--warning-foreground);
-  --radius-sm: calc(var(--radius) * 0.6);
-  --radius-md: calc(var(--radius) * 0.8);
-  --radius-lg: var(--radius);
-  --radius-xl: calc(var(--radius) * 1.4);
-  --radius-2xl: calc(var(--radius) * 1.8);
-  --radius-3xl: calc(var(--radius) * 2.2);
-  --radius-4xl: calc(var(--radius) * 2.6);
-}
+  --color-border: var(--border);
+  --color-input: var(--input);
+  --color-ring: var(--ring);
+  --color-chart-1: var(--chart-1);
+  --color-chart-2: var(--chart-2);
+  --color-chart-3: var(--chart-3);
+  --color-chart-4: var(--chart-4);
+  --color-chart-5: var(--chart-5);
+  --color-sidebar: var(--sidebar);
+  --color-sidebar-foreground: var(--sidebar-foreground);
+  --color-sidebar-primary: var(--sidebar-primary);
+  --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
+  --color-sidebar-accent: var(--sidebar-accent);
+  --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
+  --color-sidebar-border: var(--sidebar-border);
+  --color-sidebar-ring: var(--sidebar-ring);
 
-:root {
-  --background: oklch(0.985 0.005 75);
-  --foreground: oklch(0.20 0.02 65);
-  --card: oklch(0.995 0.003 75);
-  --card-foreground: oklch(0.20 0.02 65);
-  --popover: oklch(0.995 0.003 75);
-  --popover-foreground: oklch(0.20 0.02 65);
-  --primary: oklch(0.47 0.10 138);
-  --primary-foreground: oklch(0.99 0 0);
-  --secondary: oklch(0.95 0.015 75);
-  --secondary-foreground: oklch(0.28 0.02 65);
-  --muted: oklch(0.94 0.012 75);
-  --muted-foreground: oklch(0.48 0.02 65);
-  --accent: oklch(0.90 0.04 38);
-  --accent-foreground: oklch(0.25 0.03 40);
-  --destructive: oklch(0.577 0.245 27.325);
-  --success: oklch(0.55 0.16 150);
-  --success-foreground: oklch(0.99 0 0);
-  --warning: oklch(0.75 0.12 70);
-  --warning-foreground: oklch(0.25 0.04 65);
-  --border: oklch(0.90 0.015 75);
-  --input: oklch(0.90 0.015 75);
-  --ring: oklch(0.50 0.08 138);
-  --chart-1: oklch(0.55 0.12 138);
-  --chart-2: oklch(0.65 0.10 38);
-  --chart-3: oklch(0.55 0.18 30);
-  --chart-4: oklch(0.60 0.12 200);
-  --chart-5: oklch(0.50 0.10 300);
-  --radius: 0.625rem;
-  --sidebar: oklch(0.97 0.008 75);
-  --sidebar-foreground: oklch(0.20 0.02 65);
-  --sidebar-primary: oklch(0.47 0.10 138);
-  --sidebar-primary-foreground: oklch(0.99 0 0);
-  --sidebar-accent: oklch(0.95 0.015 75);
-  --sidebar-accent-foreground: oklch(0.28 0.02 65);
-  --sidebar-border: oklch(0.90 0.015 75);
-  --sidebar-ring: oklch(0.50 0.08 138);
-}
+  /* Fonts (already wired via next/font in layout.tsx) */
+  --font-sans: var(--font-geist-sans);
+  --font-mono: var(--font-geist-mono);
 
-.dark {
-  --background: oklch(0.17 0.015 65);
-  --foreground: oklch(0.93 0.008 75);
-  --card: oklch(0.22 0.015 65);
-  --card-foreground: oklch(0.93 0.008 75);
-  --popover: oklch(0.22 0.015 65);
-  --popover-foreground: oklch(0.93 0.008 75);
-  --primary: oklch(0.62 0.13 138);
-  --primary-foreground: oklch(0.16 0.02 138);
-  --secondary: oklch(0.28 0.015 65);
-  --secondary-foreground: oklch(0.93 0.008 75);
-  --muted: oklch(0.28 0.012 65);
-  --muted-foreground: oklch(0.63 0.02 65);
-  --accent: oklch(0.35 0.04 38);
-  --accent-foreground: oklch(0.93 0.008 75);
-  --destructive: oklch(0.704 0.191 22.216);
-  --success: oklch(0.62 0.14 150);
-  --success-foreground: oklch(0.16 0.02 150);
-  --warning: oklch(0.72 0.11 70);
-  --warning-foreground: oklch(0.20 0.04 65);
-  --border: oklch(1 0.008 75 / 12%);
-  --input: oklch(1 0.008 75 / 15%);
-  --ring: oklch(0.58 0.10 138);
-  --chart-1: oklch(0.62 0.13 138);
-  --chart-2: oklch(0.70 0.10 38);
-  --chart-3: oklch(0.60 0.18 30);
-  --chart-4: oklch(0.65 0.12 200);
-  --chart-5: oklch(0.55 0.10 300);
-  --sidebar: oklch(0.22 0.015 65);
-  --sidebar-foreground: oklch(0.93 0.008 75);
-  --sidebar-primary: oklch(0.62 0.13 138);
-  --sidebar-primary-foreground: oklch(0.16 0.02 138);
-  --sidebar-accent: oklch(0.28 0.015 65);
-  --sidebar-accent-foreground: oklch(0.93 0.008 75);
-  --sidebar-border: oklch(1 0.008 75 / 12%);
-  --sidebar-ring: oklch(0.58 0.10 138);
+  /* Editorial type scale → `text-display`, `text-h1`, …, `text-eyebrow` */
+  --text-display: 56px;
+  --text-display--line-height: 1;
+  --text-display--letter-spacing: -0.03em;
+  --text-display--font-weight: 500;
+
+  --text-h1: 44px;
+  --text-h1--line-height: 1.05;
+  --text-h1--letter-spacing: -0.025em;
+  --text-h1--font-weight: 500;
+
+  --text-h2: 28px;
+  --text-h2--line-height: 1.15;
+  --text-h2--letter-spacing: -0.02em;
+  --text-h2--font-weight: 500;
+
+  --text-h3: 22px;
+  --text-h3--line-height: 1.2;
+  --text-h3--letter-spacing: -0.015em;
+  --text-h3--font-weight: 500;
+
+  --text-h4: 18px;
+  --text-h4--line-height: 1.3;
+  --text-h4--letter-spacing: -0.01em;
+  --text-h4--font-weight: 500;
+
+  --text-body: 14px;
+  --text-body--line-height: 1.5;
+
+  --text-body-sm: 13px;
+  --text-body-sm--line-height: 1.5;
+
+  --text-caption: 12.5px;
+  --text-caption--line-height: 1.5;
+
+  --text-eyebrow: 11px;
+  --text-eyebrow--line-height: 1;
+  --text-eyebrow--letter-spacing: 0.08em;
+
+  --text-mono-sm: 12px;
+  --text-mono-sm--line-height: 1.4;
+
+  /* Radii — `rounded-xs|sm|md|lg|pill` */
+  --radius-xs: 6px;
+  --radius-sm: 10px;
+  --radius-md: 14px;
+  --radius-lg: 20px;
+  --radius-pill: 9999px;
+
+  /* Motion — `duration-fast|medium`, `ease-editorial` */
+  --default-transition-timing-function: var(--ease-editorial);
+  --default-transition-duration: var(--duration-fast);
+  --animate-duration-fast: var(--duration-fast);
+  --animate-duration-medium: var(--duration-medium);
+  --ease-editorial: var(--ease-editorial);
 }
 
 @layer base {
@@ -133,9 +224,33 @@
     @apply border-border outline-ring/50;
   }
   body {
-    @apply bg-background text-foreground;
+    @apply bg-paper text-ink;
+    text-wrap: pretty;
   }
   html {
     @apply font-sans;
+  }
+  h1, h2, h3, h4 {
+    text-wrap: balance;
+  }
+  /* Eyebrow: mono uppercase tracked label, ink-3. Apply via `.eyebrow`. */
+  .eyebrow {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    line-height: 1;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--ink-3);
+  }
+  /* Honor reduced-motion: collapse transforms, keep brief opacity fade */
+  @media (prefers-reduced-motion: reduce) {
+    *,
+    *::before,
+    *::after {
+      animation-duration: 0.01ms !important;
+      animation-iteration-count: 1 !important;
+      transition-duration: 80ms !important;
+      transition-property: opacity !important;
+    }
   }
 }


### PR DESCRIPTION
## Summary

Phase 1 of #86 — the Editorial design system foundation. Replaces the olive/terracotta palette with paper/ink + a single forest accent, lands the design handoff folder as the canonical visual contract, and ships the type/radius/motion utilities the rest of the makeover will consume. **No new screens or components in this PR** — just the token layer, so existing primitives keep rendering (with new colors).

## What changed

- **`src/app/globals.css`** — new Editorial palette declared as named CSS custom properties on `:root` (`--paper`, `--ink`, `--forest`, `--paper-edge`, `--forest-soft`, `--amber-soft`/`--amber-ink`, `--slate-soft`/`--slate-ink`, `--rose-soft`/`--rose-ink`, `--ink-2`, `--ink-3`, `--forest-2`). shadcn semantic tokens (`--background`, `--primary`, `--muted`, `--border`, …) are **re-bound** to the named tokens so existing components continue to render. Editorial dark-mode variants per the spec.
- **Tailwind v4 utilities** via `@theme inline`:
  - Color: `bg-paper`, `text-ink`, `border-paper-edge`, `bg-forest-soft text-forest-2`, `bg-amber-soft text-amber-ink`, `bg-slate-soft text-slate-ink`, `bg-rose-soft text-rose-ink`, plus the `--ink-2`/`--ink-3`/`--forest-2` text variants.
  - Type: `text-display` (56), `text-h1` (44), `text-h2` (28), `text-h3` (22), `text-h4` (18), `text-body`, `text-body-sm`, `text-caption`, `text-eyebrow` (11 mono uppercase tracked), `text-mono-sm`.
  - Radii: `rounded-xs` (6) / `rounded-sm` (10) / `rounded-md` (14, default) / `rounded-lg` (20) / `rounded-pill`.
  - Motion: `duration-fast` (160ms), `duration-medium` (220ms), `ease-editorial`.
- **`@layer base`** — `body` defaults to `bg-paper text-ink` with `text-wrap: pretty`; headings use `text-wrap: balance`; an `.eyebrow` helper class for mono-uppercase labels; `prefers-reduced-motion: reduce` collapses transforms to an 80ms opacity fade.
- **`design/`** (new) — the Claude design handoff: `tokens.json` (machine-readable contract), `design-system.md` (pillars / type / color / motion / components), `spec.md` (screen-by-screen), `data-model.ts` (suggested TS types), `README.md`.
- **`docs/design-system.md`** — replaced with a pointer to `design/` plus a quick-reference of the new tokens and utilities. The previous olive/terracotta documentation is retired (per #86).

## Why semantic re-binding

The fastest safe way to swap the palette without rewriting every primitive: keep `--primary`, `--background`, `--border`, etc. as the public interface for shadcn / our existing components, but resolve them to Editorial values. New components (Pill, Drawer, KidNote, EventChip, CadencePulse, …) will consume the named tokens (`--forest-soft`, `--amber-soft`, `--paper-edge`) directly so their styling is unambiguous in code review.

## Out of scope (follow-up PRs)

- New portable primitives — `Pill`, `Eyebrow` component, `HairlineList`, `Drawer`, `Modal`, refreshed `Button`. (Phase 1.2)
- Week screen redesign — hero, hairline day rows, `SwapDrawer`, `CadencePulse`, `KidNote`. (Phase 2)
- New routes — Library, Cadence, Grocery as own page, Settings, Add Meal modal. (Phase 3)
- Motion / density / a11y polish. (Phase 4)

## Test plan

- [x] `npm run build` — production build compiles cleanly.
- [x] `npm run test` — all 433 unit/component tests pass with the new tokens (no test was coupled to specific olive/terracotta hex values).
- [x] `npm run lint` — clean.
- [ ] Reviewer: pull the branch, `npm run dev`, verify the home page renders with paper-and-ink + forest greens (not olive/terracotta), no broken contrast, no missing icons.

Closes a checkbox on #86 (Phase 1 — tokens). The "retire old design tokens" item is folded in here since the tokens *are* the olive ones.